### PR TITLE
LogWrapper interface created - an interface that wraps log calls to abstract the use of log calls throughtout the application. LogWrapperFactory - Creates a LogWrapper instance. Used to control the LogWrapper-s creation in a single place with a unified API (create(string tag))  NativeLogWrapper - An implementation of the LogWrapper interface using Android's native logger.

### DIFF
--- a/app/src/main/java/com/teamagam/gimelgimel/app/common/logging/LogWrapper.java
+++ b/app/src/main/java/com/teamagam/gimelgimel/app/common/logging/LogWrapper.java
@@ -1,0 +1,43 @@
+package com.teamagam.gimelgimel.app.common.logging;
+
+/**
+ * Log wrapper class to abstract the use of loggers.
+ * Contains application-specific logging functionality.
+ */
+public interface LogWrapper {
+
+    void d(String message);
+    void d(String message, Throwable tr);
+
+    void e(String message);
+    void e(String message, Throwable tr);
+
+    void i(String message);
+    void i(String message, Throwable tr);
+
+    void v(String message);
+    void v(String message, Throwable tr);
+
+    void w(String message);
+    void w(String message, Throwable tr);
+
+    void userInteraction(String message);
+
+    void onCreate();
+    void onCreate(String message);
+
+    void onStart();
+    void onStart(String message);
+
+    void onResume();
+    void onResume(String message);
+
+    void onPause();
+    void onPause(String message);
+
+    void onStop();
+    void onStop(String message);
+
+    void onDestroy();
+    void onDestroy(String message);
+}

--- a/app/src/main/java/com/teamagam/gimelgimel/app/common/logging/LogWrapper.java
+++ b/app/src/main/java/com/teamagam/gimelgimel/app/common/logging/LogWrapper.java
@@ -29,6 +29,9 @@ public interface LogWrapper {
     void onStart();
     void onStart(String message);
 
+    void onRestart();
+    void onRestart(String message);
+
     void onResume();
     void onResume(String message);
 
@@ -40,4 +43,19 @@ public interface LogWrapper {
 
     void onDestroy();
     void onDestroy(String message);
+
+    void onAttach();
+    void onAttach(String message);
+
+    void onCreateView();
+    void onCreateView(String message);
+
+    void onActivityCreated();
+    void onActivityCreated(String message);
+
+    void onDestroyView();
+    void onDestroyView(String message);
+
+    void onDetach();
+    void onDetach(String message);
 }

--- a/app/src/main/java/com/teamagam/gimelgimel/app/common/logging/LogWrapperFactory.java
+++ b/app/src/main/java/com/teamagam/gimelgimel/app/common/logging/LogWrapperFactory.java
@@ -8,4 +8,8 @@ public class LogWrapperFactory {
     public static LogWrapper create(String tag) {
         return new NativeLogWrapper(tag);
     }
+
+    public static LogWrapper create(Class loggingClass) {
+        return create(loggingClass.getSimpleName());
+    }
 }

--- a/app/src/main/java/com/teamagam/gimelgimel/app/common/logging/LogWrapperFactory.java
+++ b/app/src/main/java/com/teamagam/gimelgimel/app/common/logging/LogWrapperFactory.java
@@ -1,0 +1,11 @@
+package com.teamagam.gimelgimel.app.common.logging;
+
+/**
+ * A simple factory class to enable future different concrete implementations
+ * to different tags and an easy way to change the LogWrapper implementation throughout the app.
+ */
+public class LogWrapperFactory {
+    public static LogWrapper create(String tag) {
+        return new NativeLogWrapper(tag);
+    }
+}

--- a/app/src/main/java/com/teamagam/gimelgimel/app/common/logging/NativeLogWrapper.java
+++ b/app/src/main/java/com/teamagam/gimelgimel/app/common/logging/NativeLogWrapper.java
@@ -93,6 +93,16 @@ public class NativeLogWrapper implements LogWrapper {
     }
 
     @Override
+    public void onRestart() {
+        onRestart("");
+    }
+
+    @Override
+    public void onRestart(String message) {
+        logCustom(createLifecyclePrefix("onRestart"), message);
+    }
+
+    @Override
     public void onResume() {
         onResume("");
     }
@@ -130,6 +140,56 @@ public class NativeLogWrapper implements LogWrapper {
     @Override
     public void onDestroy(String message) {
         logCustom(createLifecyclePrefix("onDestroy"), message);
+    }
+
+    @Override
+    public void onAttach() {
+        onAttach("");
+    }
+
+    @Override
+    public void onAttach(String message) {
+        logCustom(createLifecyclePrefix("onAttach"), message);
+    }
+
+    @Override
+    public void onCreateView() {
+        onCreateView("");
+    }
+
+    @Override
+    public void onCreateView(String message) {
+        logCustom(createLifecyclePrefix("onCreateView"), message);
+    }
+
+    @Override
+    public void onActivityCreated() {
+        onActivityCreated("");
+    }
+
+    @Override
+    public void onActivityCreated(String message) {
+        logCustom(createLifecyclePrefix("onActivityCreated"), message);
+    }
+
+    @Override
+    public void onDestroyView() {
+        onDestroyView("");
+    }
+
+    @Override
+    public void onDestroyView(String message) {
+        logCustom(createLifecyclePrefix("onDestoryView"), message);
+    }
+
+    @Override
+    public void onDetach() {
+        onDetach("");
+    }
+
+    @Override
+    public void onDetach(String message) {
+        logCustom(createLifecyclePrefix("onDetach"), message);
     }
 
     private String createLifecyclePrefix(String lifecycleType) {

--- a/app/src/main/java/com/teamagam/gimelgimel/app/common/logging/NativeLogWrapper.java
+++ b/app/src/main/java/com/teamagam/gimelgimel/app/common/logging/NativeLogWrapper.java
@@ -1,0 +1,142 @@
+package com.teamagam.gimelgimel.app.common.logging;
+
+import android.util.Log;
+
+/**
+ * Wraps the native android logger and delegates logging calls to it.
+ * Special logging methods are logged with DEBUG verbosity with a suitable prefix
+ */
+public class NativeLogWrapper implements LogWrapper {
+
+    private static final String USER_INTERACTION_PREFIX = "USER INTERACTION";
+    private static final String LIFE_CYCLE_PREFIX = "Life Cycle";
+
+    private String mTag;
+
+    public NativeLogWrapper(String tag) {
+        mTag = tag;
+    }
+
+    @Override
+    public void d(String message) {
+        Log.d(mTag, message);
+    }
+
+    @Override
+    public void d(String message, Throwable tr) {
+        Log.d(mTag, message, tr);
+    }
+
+    @Override
+    public void e(String message) {
+        Log.e(mTag, message);
+    }
+
+    @Override
+    public void e(String message, Throwable tr) {
+        Log.e(mTag, message, tr);
+    }
+
+    @Override
+    public void i(String message) {
+        Log.i(mTag, message);
+    }
+
+    @Override
+    public void i(String message, Throwable tr) {
+        Log.i(mTag, message, tr);
+    }
+
+    @Override
+    public void v(String message) {
+        Log.v(mTag, message);
+    }
+
+    @Override
+    public void v(String message, Throwable tr) {
+        Log.v(mTag, message, tr);
+    }
+
+    @Override
+    public void w(String message) {
+        Log.w(mTag, message);
+    }
+
+    @Override
+    public void w(String message, Throwable tr) {
+        Log.w(mTag, message, tr);
+    }
+
+    @Override
+    public void userInteraction(String message) {
+        logCustom(USER_INTERACTION_PREFIX, message);
+    }
+
+    @Override
+    public void onCreate() {
+        onCreate("");
+    }
+
+    @Override
+    public void onCreate(String message) {
+        logCustom(createLifecyclePrefix("onCreate"), message);
+    }
+
+    @Override
+    public void onStart() {
+        onStart("");
+    }
+
+    @Override
+    public void onStart(String message) {
+        logCustom(createLifecyclePrefix("onStart"), message);
+    }
+
+    @Override
+    public void onResume() {
+        onResume("");
+    }
+
+    @Override
+    public void onResume(String message) {
+        logCustom(createLifecyclePrefix("onResume"), message);
+    }
+
+    @Override
+    public void onPause() {
+        onPause("");
+    }
+
+    @Override
+    public void onPause(String message) {
+        logCustom(createLifecyclePrefix("onPause"), message);
+    }
+
+    @Override
+    public void onStop() {
+        onStop("");
+    }
+
+    @Override
+    public void onStop(String message) {
+        logCustom(createLifecyclePrefix("onStop"), message);
+    }
+
+    @Override
+    public void onDestroy() {
+        onDestroy("");
+    }
+
+    @Override
+    public void onDestroy(String message) {
+        logCustom(createLifecyclePrefix("onDestroy"), message);
+    }
+
+    private String createLifecyclePrefix(String lifecycleType) {
+        return LIFE_CYCLE_PREFIX + String.format("[%s]", lifecycleType);
+    }
+
+    private void logCustom(String prefix, String message) {
+        Log.d(mTag, String.format("%s %s", prefix, message));
+    }
+}

--- a/app/src/main/java/com/teamagam/gimelgimel/app/common/logging/NativeLogWrapper.java
+++ b/app/src/main/java/com/teamagam/gimelgimel/app/common/logging/NativeLogWrapper.java
@@ -8,7 +8,7 @@ import android.util.Log;
  */
 public class NativeLogWrapper implements LogWrapper {
 
-    private static final String USER_INTERACTION_PREFIX = "USER INTERACTION";
+    private static final String USER_INTERACTION_PREFIX = "User Interaction";
     private static final String LIFE_CYCLE_PREFIX = "Life Cycle";
 
     private String mTag;
@@ -179,7 +179,7 @@ public class NativeLogWrapper implements LogWrapper {
 
     @Override
     public void onDestroyView(String message) {
-        logCustom(createLifecyclePrefix("onDestoryView"), message);
+        logCustom(createLifecyclePrefix("onDestroyView"), message);
     }
 
     @Override
@@ -193,10 +193,10 @@ public class NativeLogWrapper implements LogWrapper {
     }
 
     private String createLifecyclePrefix(String lifecycleType) {
-        return LIFE_CYCLE_PREFIX + String.format("[%s]", lifecycleType);
+        return LIFE_CYCLE_PREFIX + String.format("(%s)", lifecycleType);
     }
 
     private void logCustom(String prefix, String message) {
-        Log.d(mTag, String.format("%s %s", prefix, message));
+        Log.d(mTag, String.format("[%s] %s", prefix, message));
     }
 }


### PR DESCRIPTION
LogWrapper interface created - an interface that wraps log calls to abstract the use of log calls throughtout the application.
LogWrapperFactory - Creates a LogWrapper instance. Used to control the LogWrapper-s creation in a single place with a unified API (create(string tag))
 NativeLogWrapper - An implementation of the LogWrapper interface using Android's native logger.
