### PR TITLE
New feature implemented: UserLocation pins displayed on map indicate their "freshness"/relevant status. UserLocation can be "fresh" or "stale" according to how old the sample is.

### DIFF
--- a/app/src/main/java/com/teamagam/gimelgimel/app/model/ViewsModels/UsersLocationViewModel.java
+++ b/app/src/main/java/com/teamagam/gimelgimel/app/model/ViewsModels/UsersLocationViewModel.java
@@ -1,0 +1,69 @@
+package com.teamagam.gimelgimel.app.model.ViewsModels;
+
+import com.teamagam.gimelgimel.app.model.entities.UserLocation;
+import com.teamagam.gimelgimel.app.view.viewer.data.VectorLayer;
+import com.teamagam.gimelgimel.app.view.viewer.data.entities.Entity;
+import com.teamagam.gimelgimel.app.view.viewer.data.entities.Point;
+import com.teamagam.gimelgimel.app.view.viewer.data.symbols.Symbol;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Holds other users' last location
+ * Synchronizes VectorLayer with its internal state
+ */
+public class UsersLocationViewModel {
+
+    private HashMap<String, UserLocation> mUserIdToUserLocation;
+    private UserLocationSymbolizer mUserLocationSymbolizer;
+
+    public UsersLocationViewModel(UserLocationSymbolizer symbolizer) {
+        mUserIdToUserLocation = new HashMap<>();
+        mUserLocationSymbolizer = symbolizer;
+    }
+
+    public void save(UserLocation userLocation) {
+        mUserIdToUserLocation.put(userLocation.getId(), userLocation);
+    }
+
+    public void synchronizeToVectorLayer(VectorLayer vectorLayer) {
+        for (Map.Entry<String, UserLocation> kvp : mUserIdToUserLocation.entrySet()) {
+            synchronizeToVectorLayer(vectorLayer, kvp.getValue());
+        }
+    }
+
+    private void synchronizeToVectorLayer(VectorLayer vectorLayer, UserLocation userLocation) {
+        if (isUserEntityExists(vectorLayer, userLocation.getId())) {
+            updateExistingUserLocation(userLocation, vectorLayer.getEntity(userLocation.getId()));
+        } else {
+            addNewUserLocation(vectorLayer, userLocation);
+        }
+    }
+
+    private boolean isUserEntityExists(VectorLayer vectorLayer, String id) {
+        return vectorLayer.getEntity(id) != null;
+    }
+
+    private void updateExistingUserLocation(UserLocation userLocation, Entity userEntity) {
+        userEntity.updateSymbol(mUserLocationSymbolizer.symbolize(userLocation));
+    }
+
+    private void addNewUserLocation(VectorLayer vectorLayer,
+                                    UserLocation userLocation) {
+        Entity newEntity = createUserEntity(userLocation);
+        vectorLayer.addEntity(newEntity);
+    }
+
+    private Entity createUserEntity(UserLocation userLocation) {
+        return new Point.Builder()
+                .setId(userLocation.getId())
+                .setGeometry(userLocation.getLocationSample().getLocation())
+                .setSymbol(mUserLocationSymbolizer.symbolize(userLocation))
+                .build();
+    }
+
+    public interface UserLocationSymbolizer {
+        Symbol symbolize(UserLocation userLocation);
+    }
+}

--- a/app/src/main/java/com/teamagam/gimelgimel/app/model/entities/LocationSample.java
+++ b/app/src/main/java/com/teamagam/gimelgimel/app/model/entities/LocationSample.java
@@ -190,6 +190,10 @@ public class LocationSample implements Parcelable {
         return mAccuracy;
     }
 
+    public long getAgeMillis() {
+        return System.currentTimeMillis() - mTime;
+    }
+
     @Override
     public String toString() {
         StringBuilder s = new StringBuilder();

--- a/app/src/main/java/com/teamagam/gimelgimel/app/model/entities/UserLocation.java
+++ b/app/src/main/java/com/teamagam/gimelgimel/app/model/entities/UserLocation.java
@@ -1,19 +1,26 @@
 package com.teamagam.gimelgimel.app.model.entities;
 
+/**
+ * Encapsulates a location data associated with a user
+ */
 public class UserLocation {
-    private final String id;
-    private final LocationSample locationSample;
+    private final String mId;
+    private final LocationSample mLocationSample;
 
     public UserLocation(String id, LocationSample locationSample) {
-        this.id = id;
-        this.locationSample = locationSample;
+        mId = id;
+        mLocationSample = locationSample;
     }
 
     public String getId() {
-        return id;
+        return mId;
     }
 
     public LocationSample getLocationSample() {
-        return locationSample;
+        return mLocationSample;
+    }
+
+    public long getAgeMillis() {
+        return mLocationSample.getAgeMillis();
     }
 }

--- a/app/src/main/java/com/teamagam/gimelgimel/app/model/entities/UserLocation.java
+++ b/app/src/main/java/com/teamagam/gimelgimel/app/model/entities/UserLocation.java
@@ -1,0 +1,19 @@
+package com.teamagam.gimelgimel.app.model.entities;
+
+public class UserLocation {
+    private final String id;
+    private final LocationSample locationSample;
+
+    public UserLocation(String id, LocationSample locationSample) {
+        this.id = id;
+        this.locationSample = locationSample;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public LocationSample getLocationSample() {
+        return locationSample;
+    }
+}

--- a/app/src/main/java/com/teamagam/gimelgimel/app/view/fragments/ViewerFragment.java
+++ b/app/src/main/java/com/teamagam/gimelgimel/app/view/fragments/ViewerFragment.java
@@ -425,36 +425,29 @@ public class ViewerFragment extends BaseFragment<GGApplication> implements
 
         //TODO: config , add these to the static configuration file after merging configuration feature branch
         private static final long USER_LOCATION_STALE_THRESHOLD_MS = 60 * 1000;
-        private static final String ACTIVE_USER_LOCATION_PIN_COLOR_CSS_STRING = "#7FFF00";
         private static final int USER_LOCATION_PIN_SIZE_PX = 48;
+        private static final String ACTIVE_USER_LOCATION_PIN_CSS_COLOR = "#7FFF00";
         private static final String STALE_USER_LOCATION_PIN_CSS_COLOR = "#A9A9A9";
 
         @Override
         public Symbol symbolize(UserLocation userLocation) {
-            long timestampsDeltaMs = getTimestampsDeltaMs(userLocation);
-
-            sLogger.v(String.format("Symbolizing userLocation with id %s and timestamp delta %s",
-                    userLocation.getId(), timestampsDeltaMs));
-
-            if (isStaleSample(timestampsDeltaMs)) {
+            if (isStale(userLocation)) {
+                sLogger.v(String.format("Symbolizing user-location with id %s as an active user",
+                        userLocation.getId()));
                 return createActiveUserLocationSymbol(userLocation);
             } else {
+                sLogger.v(String.format("Symbolizing user-location with id %s as an inactive user",
+                        userLocation.getId()));
                 return createStaleUserLocationSymbol(userLocation);
             }
         }
 
-        private boolean isStaleSample(long timestampsDeltaMs) {
-            return timestampsDeltaMs < USER_LOCATION_STALE_THRESHOLD_MS;
-        }
-
-        private long getTimestampsDeltaMs(UserLocation userLocation) {
-            long sampleTimestampMs = userLocation.getLocationSample().getTime();
-            long currentTimestampMs = System.currentTimeMillis();
-            return currentTimestampMs - sampleTimestampMs;
+        private boolean isStale(UserLocation userLocation) {
+            return userLocation.getAgeMillis() < USER_LOCATION_STALE_THRESHOLD_MS;
         }
 
         private Symbol createActiveUserLocationSymbol(UserLocation userLocation) {
-            return new PointTextSymbol(ACTIVE_USER_LOCATION_PIN_COLOR_CSS_STRING,
+            return new PointTextSymbol(ACTIVE_USER_LOCATION_PIN_CSS_COLOR,
                     userLocation.getId(), USER_LOCATION_PIN_SIZE_PX);
         }
 

--- a/app/src/main/java/com/teamagam/gimelgimel/app/view/fragments/ViewerFragment.java
+++ b/app/src/main/java/com/teamagam/gimelgimel/app/view/fragments/ViewerFragment.java
@@ -65,8 +65,6 @@ public class ViewerFragment extends BaseFragment<GGApplication> implements
         SendGeographicMessageDialog.SendGeographicMessageDialogInterface,
         ShowMessageDialogFragment.ShowMessageDialogFragmentInterface, OnGGMapReadyListener {
 
-    private static final Logger sLogger = LoggerFactory.create(ViewerFragment.class);
-
     //todo: config. after merging configuration branch move this configuration to Constants.java
     private static final int USERS_LOCATION_REFRESH_FREQUENCY_MS = 5000;
     private static final int REQUEST_IMAGE_CAPTURE = 1;
@@ -420,9 +418,6 @@ public class ViewerFragment extends BaseFragment<GGApplication> implements
 
     private static class ElapsedTimeUserLocationSymbolizer implements UsersLocationViewModel.UserLocationSymbolizer {
 
-        private static final Logger sLogger = LoggerFactory.create(
-                ElapsedTimeUserLocationSymbolizer.class);
-
         //TODO: config , add these to the static configuration file after merging configuration feature branch
         private static final long USER_LOCATION_STALE_THRESHOLD_MS = 60 * 1000;
         private static final int USER_LOCATION_PIN_SIZE_PX = 48;
@@ -432,12 +427,8 @@ public class ViewerFragment extends BaseFragment<GGApplication> implements
         @Override
         public Symbol symbolize(UserLocation userLocation) {
             if (isStale(userLocation)) {
-                sLogger.v(String.format("Symbolizing user-location with id %s as an active user",
-                        userLocation.getId()));
                 return createActiveUserLocationSymbol(userLocation);
             } else {
-                sLogger.v(String.format("Symbolizing user-location with id %s as an inactive user",
-                        userLocation.getId()));
                 return createStaleUserLocationSymbol(userLocation);
             }
         }
@@ -459,8 +450,7 @@ public class ViewerFragment extends BaseFragment<GGApplication> implements
 
     private class UserLocationMessageHandler implements MessageBroadcastReceiver.NewMessageHandler {
 
-        private final Logger mLogger = LoggerFactory.create(
-                UserLocationMessageHandler.class);
+        private final Logger mLogger = LoggerFactory.create(UserLocationMessageHandler.class);
 
         @Override
         public void onNewMessage(Message msg) {

--- a/app/src/main/java/com/teamagam/gimelgimel/app/view/viewer/data/entities/Point.java
+++ b/app/src/main/java/com/teamagam/gimelgimel/app/view/viewer/data/entities/Point.java
@@ -12,7 +12,7 @@ import com.teamagam.gimelgimel.app.view.viewer.data.symbols.Symbol;
  */
 public class Point extends AbsEntity {
 
-    private static final String sPointPrefix = "point";;
+    private static final String sPointPrefix = "point";
     private PointGeometry mPointGeometry;
     private PointSymbol mPointSymbol;
 
@@ -63,7 +63,7 @@ public class Point extends AbsEntity {
         visitor.visit(this);
     }
 
-    public static class Builder extends EntityBuilder<Builder, Point>{
+    public static class Builder extends EntityBuilder<Builder, Point> {
 
         @Override
         protected Builder getThis() {


### PR DESCRIPTION
New feature implemented: UserLocation pins displayed on map indicate their "freshness"/relevant status. UserLocation can be "fresh" or "stale" according to how old the sample is.

Added classes:
UserLocation a data-class that encapsulates both the associated user's Id and LocationSample
UsersLocationViewModel - class that holds all the UserLocation objects that needs to be displayed.
    Takes in a UserLocationSymbolizer that given UserLocation determines how to symbolize it over the map.

Refactored:
ViewerFragment - All the logic/responsibilty of displaying user-location is now moved inside the UsersLocationViewModel, therefore the class was refactored to use it.
 It uses a periodical runnable (that is executed via the fragment's thread) that updates the user location pins every 5 seconds, regardless of when the last user location message arrived [this is done to allow the update of pins becoming stale over time].
 It implements a symbolizer named ElapsedTimedUserLocationSymbolizer that creates different symbols to user location pins depending of how "old" the user-location is (if its stale or not).
 Initialized UsersLocationViewModel with said symbolizer.
Boyscout cleaning - turned the anonymous user location new message handler class into an inner-class.
refactored it too to use the UsersLocationViewModel.

Boyscout cleaning - double semicolon from Point class.
