### PR TITLE
bug/disk_logger

### DIFF
--- a/app/src/debug/java/com/teamagam/gimelgimel/app/utils/Constants.java
+++ b/app/src/debug/java/com/teamagam/gimelgimel/app/utils/Constants.java
@@ -26,4 +26,9 @@ public class Constants {
 
     public static final long USERS_LOCATION_REFRESH_FREQUENCY_MS = 5 * 1000;
     public static final float ZOOM_IN_FACTOR = 0.5f;
+
+    //Disk-Logger
+    public static final String LOG_FILE_NAME_SUFFIX = "log.txt";
+    public static final String LOG_DIR_NAME = "Logs";
+    public static final int MAX_WRITE_RETRIES = 3;
 }

--- a/app/src/main/java/com/teamagam/gimelgimel/app/common/logging/LoggerFactory.java
+++ b/app/src/main/java/com/teamagam/gimelgimel/app/common/logging/LoggerFactory.java
@@ -37,6 +37,25 @@ public class LoggerFactory {
         return create(loggingClass.getSimpleName());
     }
 
+    public static Logger create() {
+        String simpleClassName = getClassSimpleName();
+        return create(simpleClassName);
+    }
+
+    private static String getClassSimpleName() {
+        StackTraceElement stackTrace[] = Thread.currentThread().getStackTrace();
+
+        //take stackTrace element at index 4 because:
+        //0: VMStack.getThreadStackTrace(Native Method)
+        //1: java.lang.Thread.getStackTrace
+        //2: LogFactory.getClassSimpleName method (this method)
+        //3: LogFactory.create
+        //4: this is the calling method!
+        String callingClassFullName = stackTrace[4].getClassName();
+        return callingClassFullName.substring(
+                callingClassFullName.lastIndexOf(".") + 1);
+    }
+
     private static List<Logger> createLoggers(String tag) {
         List<Logger> loggers = new ArrayList<>(2);
 

--- a/app/src/main/java/com/teamagam/gimelgimel/app/control/sensors/LocationFetcher.java
+++ b/app/src/main/java/com/teamagam/gimelgimel/app/control/sensors/LocationFetcher.java
@@ -18,7 +18,6 @@ import android.support.v4.app.ActivityCompat;
 import android.support.v4.content.ContextCompat;
 import android.support.v4.content.LocalBroadcastManager;
 
-import com.teamagam.gimelgimel.R;
 import com.teamagam.gimelgimel.app.control.receivers.GpsStatusBroadcastReceiver;
 import com.teamagam.gimelgimel.app.model.entities.LocationSample;
 import com.teamagam.gimelgimel.app.utils.Constants;
@@ -141,9 +140,13 @@ public class LocationFetcher {
             throw new RuntimeException("Cannot add providers to an already registered fetcher!");
         }
 
+        if (!isProviderExistsAndEnabled(locationProvider)) {
+            throw new RuntimeException(
+                    "Provider " + locationProvider + " is not supported/enabled on this device");
+        }
+
         mProviders.add(locationProvider);
     }
-
 
     /**
      * Registers fetcher for location updates
@@ -191,6 +194,10 @@ public class LocationFetcher {
         broadcastLocation(locationSample);
 
         mLastLocation = locationSample;
+    }
+
+    private boolean isProviderExistsAndEnabled(@ProviderType String locationProvider) {
+        return mLocationManager.isProviderEnabled(locationProvider);
     }
 
     private void notifyGpsStatus(Location location) {
@@ -303,9 +310,11 @@ public class LocationFetcher {
 
         private void raiseCurrentStatus() {
             if (mLastWorkingState == WORKING_STATE_STOPPED) {
-                GpsStatusBroadcastReceiver.broadcastGpsStatus(LocationFetcher.this.mAppContext, false);
+                GpsStatusBroadcastReceiver.broadcastGpsStatus(LocationFetcher.this.mAppContext,
+                        false);
             } else {
-                GpsStatusBroadcastReceiver.broadcastGpsStatus(LocationFetcher.this.mAppContext, true);
+                GpsStatusBroadcastReceiver.broadcastGpsStatus(LocationFetcher.this.mAppContext,
+                        true);
             }
         }
     }

--- a/app/src/main/java/com/teamagam/gimelgimel/app/model/ViewsModels/UsersLocationViewModel.java
+++ b/app/src/main/java/com/teamagam/gimelgimel/app/model/ViewsModels/UsersLocationViewModel.java
@@ -47,6 +47,7 @@ public class UsersLocationViewModel {
 
     private void updateExistingUserLocation(UserLocation userLocation, Entity userEntity) {
         userEntity.updateSymbol(mUserLocationSymbolizer.symbolize(userLocation));
+        userEntity.updateGeometry(userLocation.getLocationSample().getLocation());
     }
 
     private void addNewUserLocation(VectorLayer vectorLayer,

--- a/app/src/main/java/com/teamagam/gimelgimel/app/view/BaseActivity.java
+++ b/app/src/main/java/com/teamagam/gimelgimel/app/view/BaseActivity.java
@@ -11,12 +11,6 @@ import com.teamagam.gimelgimel.app.common.logging.LoggerFactory;
 
 public abstract class BaseActivity<T extends Application> extends AppCompatActivity {
 
-    @Override
-    public void onBackPressed() {
-        sLogger.userInteraction("Back key pressed");
-        super.onBackPressed();
-    }
-
     protected final String TAG = ((Object) this).getClass().getSimpleName();
 
     protected final Logger sLogger = LoggerFactory.create(((Object) this).getClass());
@@ -27,7 +21,11 @@ public abstract class BaseActivity<T extends Application> extends AppCompatActiv
 
     protected boolean mIsTwoPane;
 
-    protected Location mLocation;
+    @Override
+    public void onBackPressed() {
+        sLogger.userInteraction("Back key pressed");
+        super.onBackPressed();
+    }
 
 
     @Override

--- a/app/src/main/java/com/teamagam/gimelgimel/app/view/LauncherActivity.java
+++ b/app/src/main/java/com/teamagam/gimelgimel/app/view/LauncherActivity.java
@@ -11,11 +11,15 @@ import android.os.StrictMode;
 import com.teamagam.gimelgimel.BuildConfig;
 import com.teamagam.gimelgimel.R;
 import com.teamagam.gimelgimel.app.GGApplication;
+import com.teamagam.gimelgimel.app.common.logging.Logger;
+import com.teamagam.gimelgimel.app.common.logging.LoggerFactory;
 import com.teamagam.gimelgimel.app.control.receivers.NewLocationBroadcastReceiver;
 import com.teamagam.gimelgimel.app.control.sensors.LocationFetcher;
 import com.teamagam.gimelgimel.app.network.services.GGMessageSender;
 
 public class LauncherActivity extends Activity {
+
+    private Logger sLogger = LoggerFactory.create();
 
     protected GGApplication mApp;
 
@@ -55,9 +59,10 @@ public class LauncherActivity extends Activity {
         mLocationFetcher = LocationFetcher.getInstance(this);
 
         try {
-            mLocationFetcher.addProvider(LocationFetcher.ProviderType.LOCATION_PROVIDER_GPS);
-            mLocationFetcher.addProvider(LocationFetcher.ProviderType.LOCATION_PROVIDER_NETWORK);
-            mLocationFetcher.addProvider(LocationFetcher.ProviderType.LOCATION_PROVIDER_PASSIVE);
+            tryAddProvider(LocationFetcher.ProviderType.LOCATION_PROVIDER_GPS);
+            tryAddProvider(LocationFetcher.ProviderType.LOCATION_PROVIDER_NETWORK);
+            tryAddProvider(LocationFetcher.ProviderType.LOCATION_PROVIDER_PASSIVE);
+
             mLocationFetcher.requestLocationUpdates(mLocationMinUpdatesMs, mLocationMinDistanceM);
 
             //if the registration was OK and no SecurityException was thrown
@@ -95,6 +100,14 @@ public class LauncherActivity extends Activity {
         }
 
         startMainActivity();
+    }
+
+    private void tryAddProvider(String locationProviderGps) {
+        try {
+            mLocationFetcher.addProvider(locationProviderGps);
+        } catch (RuntimeException ex) {
+            sLogger.w("Failed adding provider " + locationProviderGps, ex);
+        }
     }
 
     private void registerLocationReceiver() {

--- a/app/src/main/java/com/teamagam/gimelgimel/app/view/MainActivity.java
+++ b/app/src/main/java/com/teamagam/gimelgimel/app/view/MainActivity.java
@@ -265,6 +265,7 @@ public class MainActivity extends BaseActivity<GGApplication>
         GGMessageLongPollingService.stopMessagePollingAsync(this);
 
         LocalBroadcastManager.getInstance(this).unregisterReceiver(mConnectivityStatusReceiver);
+        LocalBroadcastManager.getInstance(this).unregisterReceiver(mGpsStatusAlertBroadcastReceiver);
     }
 
     @Override

--- a/app/src/release/java/com/teamagam/gimelgimel/app/utils/Constants.java
+++ b/app/src/release/java/com/teamagam/gimelgimel/app/utils/Constants.java
@@ -26,4 +26,9 @@ public class Constants {
 
     public static final long USERS_LOCATION_REFRESH_FREQUENCY_MS = 5 * 1000;
     public static final float ZOOM_IN_FACTOR = 0.5f;
+
+    //Disk-Logger
+    public static final String LOG_FILE_NAME_SUFFIX = "log.txt";
+    public static final String LOG_DIR_NAME = "Logs";
+    public static final int MAX_WRITE_RETRIES = 3;
 }

--- a/app/src/test/java/com/teamagam/gimelgimel/app/control/sensors/LocationFetcherTest.java
+++ b/app/src/test/java/com/teamagam/gimelgimel/app/control/sensors/LocationFetcherTest.java
@@ -78,10 +78,21 @@ public class LocationFetcherTest {
     }
 
     @Test(expected = RuntimeException.class)
-    public void testAddProvider_alreadyRegistered_shouldThrow() throws Exception {
+    public void testAddProvider_alreadyReceivingUpdated_shouldThrow() throws Exception {
         //Arrange
+        when(mLocationManagerMock.isProviderEnabled(ProviderType.LOCATION_PROVIDER_GPS)).thenReturn(true);
+        when(mLocationManagerMock.isProviderEnabled(ProviderType.LOCATION_PROVIDER_NETWORK)).thenReturn(true);
         mLocationFetcher.addProvider(ProviderType.LOCATION_PROVIDER_NETWORK);
         mLocationFetcher.requestLocationUpdates(0, 0);
+
+        //Act
+        mLocationFetcher.addProvider(ProviderType.LOCATION_PROVIDER_GPS);
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void testAddProvider_providerNotEnabled_shouldThrow() throws Exception {
+        //Arrange
+        when(mLocationManagerMock.isProviderEnabled(ProviderType.LOCATION_PROVIDER_GPS)).thenReturn(false);
 
         //Act
         mLocationFetcher.addProvider(ProviderType.LOCATION_PROVIDER_GPS);
@@ -124,6 +135,7 @@ public class LocationFetcherTest {
     @Test
     public void testUnregisterFromUpdates_validState_shouldRemoveLocationManagerUpdates() throws Exception {
         //Arrange
+        when(mLocationManagerMock.isProviderEnabled(ProviderType.LOCATION_PROVIDER_GPS)).thenReturn(true);
         mLocationFetcher.addProvider(ProviderType.LOCATION_PROVIDER_GPS);
         mLocationFetcher.requestLocationUpdates(0, 0);
 


### PR DESCRIPTION
Ended up as few different bug fixes:
1. DiskLogger - now retries log write to file (3 times) instead of throwing an exception. It will use the native logger to log failures instead of throwing and crashing the app.
2. LocationFetcher - Checks provider is supported by the device and enabled. It'll throw an exception if it isn't. LauncherActivity now tries to add the different providers.
3. UserLocationViewModel - will update user's location geometry and not just its symbology. Users' pins will move over the map now.

Other things:
1. Implemented a LoggerFactory create method without arguments that uses a tag extract by itself. (currently using the calling class simple name as the tag)
2.  Moved constants out of the DiskLogger class into Constants classes.
3. Moved a few methods to meet organization conventions

And merged BroadcastReceiver unregistration fix
