### PR TITLE
Handling badly formatted messages

### DIFF
--- a/app/src/main/java/com/teamagam/gimelgimel/app/model/ViewsModels/MessageJsonAdapter.java
+++ b/app/src/main/java/com/teamagam/gimelgimel/app/model/ViewsModels/MessageJsonAdapter.java
@@ -38,7 +38,7 @@ public class MessageJsonAdapter implements JsonSerializer<Message>, JsonDeserial
         String type = json.getAsJsonObject().get("type").getAsString();
         Class c = sClassMessageMap.get(type);
         if (c == null)
-            throw new RuntimeException("Unknown class: " + type);
+            throw new JsonParseException("Unknown message class: " + type);
 
         return context.deserialize(json, c);
     }

--- a/app/src/main/java/com/teamagam/gimelgimel/app/network/rest/RestAPI.java
+++ b/app/src/main/java/com/teamagam/gimelgimel/app/network/rest/RestAPI.java
@@ -3,11 +3,21 @@ package com.teamagam.gimelgimel.app.network.rest;
 import com.google.gson.FieldNamingPolicy;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
 import com.teamagam.gimelgimel.app.common.logging.Logger;
 import com.teamagam.gimelgimel.app.common.logging.LoggerFactory;
 import com.teamagam.gimelgimel.app.model.ViewsModels.Message;
 import com.teamagam.gimelgimel.app.model.ViewsModels.MessageJsonAdapter;
 import com.teamagam.gimelgimel.app.utils.Constants;
+
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.List;
 
 import okhttp3.OkHttpClient;
 import okhttp3.logging.HttpLoggingInterceptor;
@@ -58,9 +68,12 @@ public class RestAPI {
             // the Message class. This DateTypeAdapter will be used anytime Gson encounters a Date field.
             // The gson instance is passed as a parameter to GsonConverter, which is a wrapper
             // class for converting types.
+            MessageJsonAdapter messageJsonAdapter = new MessageJsonAdapter();
             Gson gson = new GsonBuilder()
                     .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
-                    .registerTypeAdapter(Message.class, new MessageJsonAdapter())
+                    .registerTypeAdapter(Message.class, messageJsonAdapter)
+                    .registerTypeAdapter(List.class,
+                            new MessageListJsonAdapter(messageJsonAdapter))
                     .create();
 
             Retrofit retrofit = new Retrofit.Builder()
@@ -70,6 +83,50 @@ public class RestAPI {
                     .build();
 
             return retrofit.create(GGMessagingAPI.class);
+        }
+
+        /**
+         * Handles list of messages deserialization.
+         * Will "tolerate" badly formatted message JSONs, by skipping them.
+         */
+        private static class MessageListJsonAdapter implements JsonDeserializer<List> {
+            private static Logger sLogger = LoggerFactory.create();
+
+            private MessageJsonAdapter mMessageJsonAdapter;
+
+            public MessageListJsonAdapter(MessageJsonAdapter messageJsonAdapter) {
+                mMessageJsonAdapter = messageJsonAdapter;
+            }
+
+            @Override
+            public List deserialize(JsonElement json, Type typeOfT,
+                                    JsonDeserializationContext context) throws JsonParseException {
+                JsonArray array = json.getAsJsonArray();
+                return deserializeMessagesArrayJson(context, array);
+            }
+
+            private List deserializeMessagesArrayJson(JsonDeserializationContext context,
+                                                      JsonArray array) {
+                List<Message> messages = new ArrayList<>(array.size());
+
+                for (JsonElement messageJson : array) {
+                    addToMessagesIfParsable(context, messageJson, messages);
+                }
+
+                return messages;
+            }
+
+            private void addToMessagesIfParsable(JsonDeserializationContext context,
+                                                 JsonElement messageJson,
+                                                 List<Message> dstMessageList) {
+                try {
+                    JsonObject messageJsonObject = messageJson.getAsJsonObject();
+                    Message m = mMessageJsonAdapter.deserialize(messageJsonObject, null, context);
+                    dstMessageList.add(m);
+                } catch (JsonParseException ex) {
+                    sLogger.w("Parsing message failed", ex);
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
GSON message list parsing will "tolerate" badly formatted messages by ignoring them instead of failing the whole message-list.
