### PR TITLE
User interactions logging + various bug fixes

### DIFF
--- a/app/src/debug/java/com/teamagam/gimelgimel/app/utils/Constants.java
+++ b/app/src/debug/java/com/teamagam/gimelgimel/app/utils/Constants.java
@@ -1,7 +1,7 @@
 package com.teamagam.gimelgimel.app.utils;
 
 public class Constants {
-    public static final String MESSAGING_SERVER_URL = "http://ggmessaging-dev2.herokuapp.com";
+    public static final String MESSAGING_SERVER_URL = "http://ggmessaging-dev1.herokuapp.com";
 
     public static final int COMPRESSED_IMAGE_MAX_DIMENSION_PIXELS = 1024;
     public static final int COMPRESSED_IMAGE_JPEG_QUALITY = 70;
@@ -27,17 +27,14 @@ public class Constants {
     public static final long USERS_LOCATION_REFRESH_FREQUENCY_MS = 5 * 1000;
     public static final float ZOOM_IN_FACTOR = 0.5f;
 
-    //Disk-Logger
-    public static final String LOG_FILE_NAME_SUFFIX = "log.txt";
-    public static final String LOG_DIR_NAME = "Logs";
-    public static final int MAX_WRITE_RETRIES = 3;
-
     //Message Long polling exponential backoff configuration
     public static final int POLLING_EXP_BACKOFF_BASE_INTERVAL_MILLIS = 50;
     public static final int POLLING_EXP_BACKOFF_MULTIPLIER = 2;
     public static final int POLLING_EXP_BACKOFF_MAX_BACKOFF_MILLIS = 60 * 1000;
 
     // Log4jDiskLogger
+    public static final String LOG_FILE_NAME_SUFFIX = "log.txt";
+    public static final String LOG_DIR_NAME = "Logs";
     public static final int MAX_LOG_SIZE = 1024 * 1024 * 5;
     public static final int MAX_BACKUP_LOG_FILES = 10;
 }

--- a/app/src/main/java/com/teamagam/gimelgimel/app/common/logging/LoggerFactory.java
+++ b/app/src/main/java/com/teamagam/gimelgimel/app/common/logging/LoggerFactory.java
@@ -25,12 +25,11 @@ public class LoggerFactory {
     private static String sExternalStorageDirectoryPath;
 
     public static void init(Context context) {
-        sExternalStorageDirectoryPath = getExternalStorageDirectoryPath(context);
-        createDirectory(sExternalStorageDirectoryPath);
-        configureLogger(sExternalStorageDirectoryPath,
-                Constants.LOG_FILE_NAME_SUFFIX,
-                Constants.MAX_LOG_SIZE,
-                Constants.MAX_BACKUP_LOG_FILES);
+        try {
+            setupDiskLoggerConfigurations(context);
+        } catch (Exception ex) {
+            sInnerLogger.w("Disk logger setup failed", ex);
+        }
     }
 
     public static Logger create(String tag) {
@@ -79,6 +78,15 @@ public class LoggerFactory {
         return loggers;
     }
 
+    private static void setupDiskLoggerConfigurations(Context context) {
+        sExternalStorageDirectoryPath = getExternalStorageDirectoryPath(context);
+        createDirectory(sExternalStorageDirectoryPath);
+        configureLogger(sExternalStorageDirectoryPath,
+                Constants.LOG_FILE_NAME_SUFFIX,
+                Constants.MAX_LOG_SIZE,
+                Constants.MAX_BACKUP_LOG_FILES);
+    }
+
     private static void createDirectory(String directoryPath) {
         File file = new File(directoryPath);
 
@@ -87,7 +95,8 @@ public class LoggerFactory {
         }
     }
 
-    private static void configureLogger(String directory, String fileName, long maxFileSize, int maxBackupLogFiles) {
+    private static void configureLogger(String directory, String fileName, long maxFileSize,
+                                        int maxBackupLogFiles) {
         LogConfigurator logConfigurator = new LogConfigurator();
 
         logConfigurator.setFileName(directory + File.separator + fileName);

--- a/app/src/main/java/com/teamagam/gimelgimel/app/view/fragments/dialogs/SendGeographicMessageDialog.java
+++ b/app/src/main/java/com/teamagam/gimelgimel/app/view/fragments/dialogs/SendGeographicMessageDialog.java
@@ -4,6 +4,7 @@ import android.app.Activity;
 import android.app.Fragment;
 import android.os.Bundle;
 import android.view.View;
+import android.widget.AdapterView;
 import android.widget.ArrayAdapter;
 import android.widget.EditText;
 import android.widget.Spinner;
@@ -43,6 +44,7 @@ public class SendGeographicMessageDialog extends
 
     @BindView(R.id.dialog_send_geo_message_geo_types)
     Spinner mGeoTypesSpinner;
+    private AdapterView.OnItemSelectedListener mSpinnerItemSelectedLogger;
 
     /**
      * Works the same as {@link SendGeographicMessageDialog#newInstance(PointGeometry pointGeometry,
@@ -83,6 +85,18 @@ public class SendGeographicMessageDialog extends
         if (arguments != null) {
             mPoint = arguments.getParcelable(ARG_POINT_GEOMETRY);
         }
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        mGeoTypesSpinner.setOnItemSelectedListener(mSpinnerItemSelectedLogger);
+    }
+
+    @Override
+    public void onPause() {
+        super.onPause();
+        mGeoTypesSpinner.setOnItemSelectedListener(null);
     }
 
     @Override
@@ -148,9 +162,9 @@ public class SendGeographicMessageDialog extends
             new GGMessageSender(getActivity()).sendGeoMessageAsync(mPoint, mText, type);
             mInterface.drawSentPin(mPoint, type);
             dismiss();
-
         } else {
             //validate that the user has entered description
+            sLogger.userInteraction("Input not valid");
             mEditText.setError(mGeoTextValidationError);
             mEditText.requestFocus();
         }
@@ -167,6 +181,19 @@ public class SendGeographicMessageDialog extends
 
         // Apply the adapter to the spinner
         mGeoTypesSpinner.setAdapter(adapter);
+
+        mSpinnerItemSelectedLogger = new AdapterView.OnItemSelectedListener() {
+            @Override
+            public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {
+                String type = (String) mGeoTypesSpinner.getItemAtPosition(position);
+                sLogger.userInteraction("Selected message geo-type " + type);
+            }
+
+            @Override
+            public void onNothingSelected(AdapterView<?> parent) {
+
+            }
+        };
     }
 
     private boolean isInputValid() {

--- a/app/src/main/java/com/teamagam/gimelgimel/app/view/fragments/messags_panel_fragments/MessagesContainerFragment.java
+++ b/app/src/main/java/com/teamagam/gimelgimel/app/view/fragments/messags_panel_fragments/MessagesContainerFragment.java
@@ -1,10 +1,9 @@
 package com.teamagam.gimelgimel.app.view.fragments.messags_panel_fragments;
 
 
-import android.os.Bundle;
+import android.view.View;
 import android.view.ViewGroup;
 import android.widget.LinearLayout;
-import android.view.View;
 import android.widget.TextView;
 
 import com.teamagam.gimelgimel.R;
@@ -29,7 +28,7 @@ public class MessagesContainerFragment extends BaseDataFragment<ContainerMessage
 
     @BindView(R.id.master_detail_layout)
     LinearLayout mMasterDetailLayout;
-	
+
     @BindView(R.id.fragment_messages_container_nomessage_textview)
     TextView mNoMessageTV;
 
@@ -39,11 +38,6 @@ public class MessagesContainerFragment extends BaseDataFragment<ContainerMessage
 
     public MessagesContainerFragment() {
         // Required empty public constructor
-    }
-
-    @Override
-    public void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
     }
 
     @Override

--- a/app/src/main/java/com/teamagam/gimelgimel/app/view/fragments/messags_panel_fragments/MessagesDetailBaseGeoFragment.java
+++ b/app/src/main/java/com/teamagam/gimelgimel/app/view/fragments/messags_panel_fragments/MessagesDetailBaseGeoFragment.java
@@ -1,6 +1,9 @@
 package com.teamagam.gimelgimel.app.view.fragments.messags_panel_fragments;
 
+import android.annotation.TargetApi;
+import android.app.Activity;
 import android.content.Context;
+import android.os.Build;
 
 import com.teamagam.gimelgimel.app.model.ViewsModels.Message;
 import com.teamagam.gimelgimel.app.model.ViewsModels.messages.MessageDetailViewModel;
@@ -10,13 +13,27 @@ import com.teamagam.gimelgimel.app.view.viewer.data.geometries.PointGeometry;
  * A subclass {@link MessagesDetailFragment} for managing listener for goto-button.
  */
 public abstract class MessagesDetailBaseGeoFragment<VM extends
-        MessageDetailViewModel> extends MessagesDetailFragment<VM>{
+        MessageDetailViewModel> extends MessagesDetailFragment<VM> {
 
     protected GeoMessageInterface mGeoMessageListener;
 
+    @TargetApi(23)
     @Override
     public void onAttach(Context context) {
         super.onAttach(context);
+        onAttachCompat(context);
+    }
+
+    @SuppressWarnings("deprecation")
+    @Override
+    public void onAttach(Activity activity) {
+        super.onAttach(activity);
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+            onAttachCompat(activity);
+        }
+    }
+
+    private void onAttachCompat(Context context) {
         if (context instanceof GeoMessageInterface) {
             mGeoMessageListener = (GeoMessageInterface) context;
         } else {

--- a/app/src/main/java/com/teamagam/gimelgimel/app/view/fragments/messags_panel_fragments/MessagesMasterFragment.java
+++ b/app/src/main/java/com/teamagam/gimelgimel/app/view/fragments/messags_panel_fragments/MessagesMasterFragment.java
@@ -46,6 +46,7 @@ public class MessagesMasterFragment extends BaseDataFragment<MessagesViewModel, 
 
     @Override
     public void onListItemInteraction(DisplayMessage message) {
+        sLogger.userInteraction("Message [id=" + message.getMessage().getSenderId() + "] clicked");
         mViewModel.select(message);
     }
 
@@ -53,5 +54,4 @@ public class MessagesMasterFragment extends BaseDataFragment<MessagesViewModel, 
     public void updateViewsOnUiThread() {
         mAdapter.notifyDataSetChanged();
     }
-
 }

--- a/app/src/main/java/com/teamagam/gimelgimel/app/view/listeners/NavigationItemSelectedListener.java
+++ b/app/src/main/java/com/teamagam/gimelgimel/app/view/listeners/NavigationItemSelectedListener.java
@@ -10,6 +10,8 @@ import android.support.v4.widget.DrawerLayout;
 import android.view.MenuItem;
 
 import com.teamagam.gimelgimel.R;
+import com.teamagam.gimelgimel.app.common.logging.Logger;
+import com.teamagam.gimelgimel.app.common.logging.LoggerFactory;
 import com.teamagam.gimelgimel.app.view.fragments.viewer_footer_fragments.MapManipulationFooterFragment;
 import com.teamagam.gimelgimel.app.view.fragments.viewer_footer_fragments.VectorManipulationFooterFragment;
 
@@ -19,12 +21,15 @@ import com.teamagam.gimelgimel.app.view.fragments.viewer_footer_fragments.Vector
  */
 public class NavigationItemSelectedListener implements NavigationView.OnNavigationItemSelectedListener {
 
+    private static Logger sLogger = LoggerFactory.create();
+
     Activity mActivity;
     DrawerLayout mDrawerLayout;
 
     /**
      * Initializes the listeners
-     * @param activity The activity the contains the navigation view and the drawer layout
+     *
+     * @param activity     The activity the contains the navigation view and the drawer layout
      * @param drawerLayout The drawer layout that contains the navigation view
      */
     public NavigationItemSelectedListener(Activity activity, DrawerLayout drawerLayout) {
@@ -34,6 +39,7 @@ public class NavigationItemSelectedListener implements NavigationView.OnNavigati
 
     @Override
     public boolean onNavigationItemSelected(MenuItem item) {
+        sLogger.userInteraction("Drawer item " + item + " clicked");
         createFragmentByMenuItem(item);
         item.setChecked(true);
         mDrawerLayout.closeDrawers();
@@ -43,7 +49,8 @@ public class NavigationItemSelectedListener implements NavigationView.OnNavigati
     private void createFragmentByMenuItem(MenuItem item) {
         // Currently we use the footer the show views from the Drawer
         // We should change this to more flexible code to support other views
-        Fragment fragmentToDisplay = mActivity.getFragmentManager().findFragmentById(R.id.activity_main_container_footer);
+        Fragment fragmentToDisplay = mActivity.getFragmentManager().findFragmentById(
+                R.id.activity_main_container_footer);
         FragmentTransaction fragmentTransaction = mActivity.getFragmentManager().beginTransaction();
 
         switch (item.getItemId()) {
@@ -64,7 +71,8 @@ public class NavigationItemSelectedListener implements NavigationView.OnNavigati
         }
     }
 
-    private void removeFragment(FragmentTransaction fragmentTransaction, Fragment fragmentToRemove) {
+    private void removeFragment(FragmentTransaction fragmentTransaction,
+                                Fragment fragmentToRemove) {
         if (fragmentToRemove != null) {
             fragmentTransaction.remove(fragmentToRemove);
             fragmentTransaction.commit();

--- a/app/src/main/java/com/teamagam/gimelgimel/app/view/settings/SettingsActivity.java
+++ b/app/src/main/java/com/teamagam/gimelgimel/app/view/settings/SettingsActivity.java
@@ -14,6 +14,8 @@ import android.preference.PreferenceFragment;
 import android.preference.PreferenceManager;
 import android.support.v7.app.ActionBar;
 import android.view.MenuItem;
+import android.view.View;
+import android.widget.ListView;
 
 import com.teamagam.gimelgimel.R;
 import com.teamagam.gimelgimel.app.common.logging.Logger;
@@ -36,12 +38,6 @@ public class SettingsActivity extends AppCompatPreferenceActivity {
 
     private static final Logger sLogger = LoggerFactory.create(SettingsActivity.class);
 
-    @Override
-    public void onBackPressed() {
-        sLogger.userInteraction("Back key pressed");
-        super.onBackPressed();
-    }
-
     /**
      * A preference value change listener that updates the preference's summary
      * to reflect its new value.
@@ -62,9 +58,7 @@ public class SettingsActivity extends AppCompatPreferenceActivity {
                         index >= 0
                                 ? listPreference.getEntries()[index]
                                 : null);
-
-            }
-            else {
+            } else {
                 // For all other preferences, set the summary to the value's
                 // simple string representation.
                 preference.setSummary(stringValue);
@@ -104,20 +98,9 @@ public class SettingsActivity extends AppCompatPreferenceActivity {
     }
 
     @Override
-    protected void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-        setupActionBar();
-    }
-
-    /**
-     * Set up the {@link android.app.ActionBar}, if the API is available.
-     */
-    private void setupActionBar() {
-        ActionBar actionBar = getSupportActionBar();
-        if (actionBar != null) {
-            // Show the Up button in the action bar.
-            actionBar.setDisplayHomeAsUpEnabled(true);
-        }
+    public void onBackPressed() {
+        sLogger.userInteraction("Back key pressed");
+        super.onBackPressed();
     }
 
     /**
@@ -137,6 +120,22 @@ public class SettingsActivity extends AppCompatPreferenceActivity {
         loadHeadersFromResource(R.xml.pref_headers, target);
     }
 
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        switch (item.getItemId()) {
+            case android.R.id.home:
+                onBackPressed();
+                return true;
+        }
+        return super.onOptionsItemSelected(item);
+    }
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setupActionBar();
+    }
+
     /**
      * This method stops fragment injection in malicious applications.
      * Make sure to deny any unknown fragments here.
@@ -147,6 +146,18 @@ public class SettingsActivity extends AppCompatPreferenceActivity {
                 || MessagesFragment.class.getName().equals(fragmentName)
                 || GpsPreferenceFragment.class.getName().equals(fragmentName);
     }
+
+    /**
+     * Set up the {@link android.app.ActionBar}, if the API is available.
+     */
+    private void setupActionBar() {
+        ActionBar actionBar = getSupportActionBar();
+        if (actionBar != null) {
+            // Show the Up button in the action bar.
+            actionBar.setDisplayHomeAsUpEnabled(true);
+        }
+    }
+
 
     /**
      * This fragment shows general preferences only. It is used when the
@@ -221,8 +232,8 @@ public class SettingsActivity extends AppCompatPreferenceActivity {
             addPreferencesFromResource(R.xml.pref_mesages);
             setHasOptionsMenu(true);
 
-
-            bindPreferenceSummaryToValue(findPreference(getString(R.string.sync_messages_frequency_key)));
+            bindPreferenceSummaryToValue(
+                    findPreference(getString(R.string.sync_messages_frequency_key)));
         }
 
         @Override
@@ -235,15 +246,4 @@ public class SettingsActivity extends AppCompatPreferenceActivity {
             return super.onOptionsItemSelected(item);
         }
     }
-
-    @Override
-    public boolean onOptionsItemSelected(MenuItem item) {
-        switch (item.getItemId()) {
-            case android.R.id.home:
-                onBackPressed();
-                return true;
-        }
-        return super.onOptionsItemSelected(item);
-    }
-
 }

--- a/app/src/release/java/com/teamagam/gimelgimel/app/utils/Constants.java
+++ b/app/src/release/java/com/teamagam/gimelgimel/app/utils/Constants.java
@@ -27,17 +27,14 @@ public class Constants {
     public static final long USERS_LOCATION_REFRESH_FREQUENCY_MS = 5 * 1000;
     public static final float ZOOM_IN_FACTOR = 0.5f;
 
-    //Disk-Logger
-    public static final String LOG_FILE_NAME_SUFFIX = "log.txt";
-    public static final String LOG_DIR_NAME = "Logs";
-    public static final int MAX_WRITE_RETRIES = 3;
-
     //Message Long polling exponential backoff configuration
     public static final int POLLING_EXP_BACKOFF_BASE_INTERVAL_MILLIS = 50;
     public static final int POLLING_EXP_BACKOFF_MULTIPLIER = 2;
     public static final int POLLING_EXP_BACKOFF_MAX_BACKOFF_MILLIS = 60 * 1000;
 
     // Log4jDiskLogger
+    public static final String LOG_FILE_NAME_SUFFIX = "log.txt";
+    public static final String LOG_DIR_NAME = "Logs";
     public static final int MAX_LOG_SIZE = 1024 * 1024 * 5;
     public static final int MAX_BACKUP_LOG_FILES = 10;
 }


### PR DESCRIPTION
1. Handled logger initialization exceptions
2. Added user interaction logging throughout code
   2.1 - left drawer status changes
   2.2 - left drawer item clicks
   2.3 - master messages fragment item clicks
   2.4 - message container status changed
   2.5 - GeoMessage type spinner selections
3. Removed some redundant code
4. Added support for older (<Marshmallow) Android version at MessageDetailBaseGeoFragment
5. Fixed ContainerMessage's slide panel listener registration to happen at onResume instead only at onCreate, to allow it to work after onPause unregisters it.
6. Removed unused constant field & reorganized blocks
7. Organized settings activity code
