### PR TITLE
Bug fix - app crash on network changes

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -61,11 +61,11 @@
             android:exported="false">
         </service>
 
-        <receiver android:name=".app.network.receivers.NetworkChangeReceiver" >
-            <intent-filter>
-                <action android:name="android.net.conn.CONNECTIVITY_CHANGE"/>
-            </intent-filter>
-        </receiver>
+        <!--<receiver android:name=".app.network.receivers.NetworkChangeReceiver" >-->
+            <!--<intent-filter>-->
+                <!--<action android:name="android.net.conn.CONNECTIVITY_CHANGE"/>-->
+            <!--</intent-filter>-->
+        <!--</receiver>-->
 
     </application>
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -25,6 +25,7 @@
         android:label="@string/app_name"
         android:supportsRtl="true"
         android:theme="@style/Theme.GimelGimel">
+
         <activity
             android:name=".app.view.LauncherActivity"
             android:label="@string/activity_launcher_title">
@@ -34,6 +35,7 @@
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
         </activity>
+
         <activity
             android:name=".app.view.MainActivity"
             android:configChanges="orientation|screenSize"
@@ -42,6 +44,7 @@
             android:name=".app.view.settings.SettingsActivity"
             android:label="@string/activity_settings_title"
             android:theme="@style/Theme.GimelGimel.WithActionBar"/>
+
         <activity
             android:name=".app.view.LoginActivity"
             android:label="@string/title_activity_login"
@@ -50,6 +53,7 @@
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value="com.teamagam.gimelgimel.app.view.LauncherActivity"/>
         </activity>
+
         <activity
             android:name=".app.view.ImageFullscreenActivity"
             android:configChanges="orientation|keyboardHidden|screenSize"
@@ -60,12 +64,6 @@
             android:name=".app.network.services.GGImageService"
             android:exported="false">
         </service>
-
-        <!--<receiver android:name=".app.network.receivers.NetworkChangeReceiver" >-->
-            <!--<intent-filter>-->
-                <!--<action android:name="android.net.conn.CONNECTIVITY_CHANGE"/>-->
-            <!--</intent-filter>-->
-        <!--</receiver>-->
 
     </application>
 

--- a/app/src/main/java/com/teamagam/gimelgimel/app/GGApplication.java
+++ b/app/src/main/java/com/teamagam/gimelgimel/app/GGApplication.java
@@ -2,6 +2,8 @@ package com.teamagam.gimelgimel.app;
 
 import android.app.Application;
 import android.content.IntentFilter;
+import android.os.Handler;
+import android.os.HandlerThread;
 import android.preference.PreferenceManager;
 import android.support.v4.content.LocalBroadcastManager;
 
@@ -44,6 +46,7 @@ public class GGApplication extends Application {
     private ContainerMessagesViewModel mContainerMessagesViewModel;
     private MessageMapEntitiesViewModel mMessageMapEntitiesViewModel;
     private UsersLocationViewModel mUserLocationViewModel;
+    private Handler mBackgroundHandler;
 
 
     @Override
@@ -70,7 +73,6 @@ public class GGApplication extends Application {
 
             loadDefaultXmlValues(R.xml.pref_general);
             loadDefaultXmlValues(R.xml.pref_mesages);
-
         }
 
         return mPrefs;
@@ -86,6 +88,8 @@ public class GGApplication extends Application {
 
         mGpsStatusBroadcastReceiver = new GpsStatusBroadcastReceiver(this);
 
+        mBackgroundHandler = createBackgroundHandler();
+
         mRepeatedBackoffMessagePolling = RepeatedBackoffMessagePolling.create(this);
 
         LoggerFactory.init(this);
@@ -93,6 +97,12 @@ public class GGApplication extends Application {
         // Initialize the fresco plugin.
         // Should be here instead of each activity
         Fresco.initialize(this);
+    }
+
+    private Handler createBackgroundHandler() {
+        HandlerThread ht = new HandlerThread("ggBackground");
+        ht.start();
+        return new Handler(ht.getLooper());
     }
 
     private void compositeViewModels() {
@@ -105,7 +115,8 @@ public class GGApplication extends Application {
         mLatLongMessageDetailViewModel = new GeoMessageDetailViewModel(mSelectedMessageModel);
 
         EntityMessageSymbolizer symbolizer = new EntityMessageSymbolizer(this);
-        mMessageMapEntitiesViewModel = new MessageMapEntitiesViewModel(mSelectedMessageModel, symbolizer);
+        mMessageMapEntitiesViewModel = new MessageMapEntitiesViewModel(mSelectedMessageModel,
+                symbolizer);
         mUserLocationViewModel = new UsersLocationViewModel(symbolizer);
     }
 
@@ -163,5 +174,9 @@ public class GGApplication extends Application {
 
     public MessagesModel getMessagesModel() {
         return mMessagesModel;
+    }
+
+    public Handler getBackgroundHandler() {
+        return mBackgroundHandler;
     }
 }

--- a/app/src/main/java/com/teamagam/gimelgimel/app/GGApplication.java
+++ b/app/src/main/java/com/teamagam/gimelgimel/app/GGApplication.java
@@ -46,7 +46,8 @@ public class GGApplication extends Application {
     private ContainerMessagesViewModel mContainerMessagesViewModel;
     private MessageMapEntitiesViewModel mMessageMapEntitiesViewModel;
     private UsersLocationViewModel mUserLocationViewModel;
-    private Handler mBackgroundHandler;
+    private Handler mSharedBackgroundHandler;
+    private Handler mMessagingHandler;
 
 
     @Override
@@ -88,7 +89,8 @@ public class GGApplication extends Application {
 
         mGpsStatusBroadcastReceiver = new GpsStatusBroadcastReceiver(this);
 
-        mBackgroundHandler = createBackgroundHandler();
+        mSharedBackgroundHandler = createHandlerThread("backgroundThread");
+        mMessagingHandler = createHandlerThread("messaging");
 
         mRepeatedBackoffMessagePolling = RepeatedBackoffMessagePolling.create(this);
 
@@ -99,8 +101,8 @@ public class GGApplication extends Application {
         Fresco.initialize(this);
     }
 
-    private Handler createBackgroundHandler() {
-        HandlerThread ht = new HandlerThread("ggBackground");
+    private Handler createHandlerThread(String name) {
+        HandlerThread ht = new HandlerThread(name);
         ht.start();
         return new Handler(ht.getLooper());
     }
@@ -176,7 +178,11 @@ public class GGApplication extends Application {
         return mMessagesModel;
     }
 
-    public Handler getBackgroundHandler() {
-        return mBackgroundHandler;
+    public Handler getSharedBackgroundHandler() {
+        return mSharedBackgroundHandler;
+    }
+
+    public Handler getMessagingHandler(){
+        return mMessagingHandler;
     }
 }

--- a/app/src/main/java/com/teamagam/gimelgimel/app/network/receivers/NetworkChangeReceiver.java
+++ b/app/src/main/java/com/teamagam/gimelgimel/app/network/receivers/NetworkChangeReceiver.java
@@ -8,7 +8,6 @@ import android.net.NetworkInfo;
 
 import com.teamagam.gimelgimel.app.common.logging.Logger;
 import com.teamagam.gimelgimel.app.common.logging.LoggerFactory;
-import com.teamagam.gimelgimel.app.network.rest.RestAPI;
 import com.teamagam.gimelgimel.app.utils.Constants;
 
 import java.io.IOException;
@@ -33,9 +32,8 @@ public class NetworkChangeReceiver extends BroadcastReceiver {
             boolean isNetworkAvailable = isNetworkAvailable(context);
 
             broadcastConnectivityStatus(context.getApplicationContext(), isNetworkAvailable);
-        }catch (Exception ex){
-            sLogger.d("NetworkChangedReceiver onReceive failed", ex);
-            throw ex;
+        } catch (Exception ex) {
+            sLogger.w("NetworkChangedReceiver onReceive failed", ex);
         }
     }
 

--- a/app/src/main/java/com/teamagam/gimelgimel/app/network/receivers/NetworkChangeReceiver.java
+++ b/app/src/main/java/com/teamagam/gimelgimel/app/network/receivers/NetworkChangeReceiver.java
@@ -29,9 +29,14 @@ public class NetworkChangeReceiver extends BroadcastReceiver {
 
     @Override
     public void onReceive(Context context, Intent intent) {
-        boolean isNetworkAvailable = isNetworkAvailable(context);
+        try {
+            boolean isNetworkAvailable = isNetworkAvailable(context);
 
-        broadcastConnectivityStatus(context, isNetworkAvailable);
+            broadcastConnectivityStatus(context.getApplicationContext(), isNetworkAvailable);
+        }catch (Exception ex){
+            sLogger.d("NetworkChangedReceiver onReceive failed", ex);
+            throw ex;
+        }
     }
 
     /**

--- a/app/src/main/java/com/teamagam/gimelgimel/app/network/services/message_polling/RepeatedBackoffMessagePolling.java
+++ b/app/src/main/java/com/teamagam/gimelgimel/app/network/services/message_polling/RepeatedBackoffMessagePolling.java
@@ -31,7 +31,7 @@ public class RepeatedBackoffMessagePolling extends RepeatedBackoffTaskRunner {
         IMessagePoller poller = createPoller(ggApplication);
         BackoffStrategy backoffStrategy = createBackoffStrategy();
 
-        return new RepeatedBackoffMessagePolling(ggApplication.getBackgroundHandler(),
+        return new RepeatedBackoffMessagePolling(ggApplication.getMessagingHandler(),
                 backoffStrategy, poller,
                 ggApplication);
     }

--- a/app/src/main/java/com/teamagam/gimelgimel/app/network/services/message_polling/RepeatedBackoffMessagePolling.java
+++ b/app/src/main/java/com/teamagam/gimelgimel/app/network/services/message_polling/RepeatedBackoffMessagePolling.java
@@ -2,8 +2,6 @@ package com.teamagam.gimelgimel.app.network.services.message_polling;
 
 import android.content.Context;
 import android.os.Handler;
-import android.os.HandlerThread;
-import android.os.Looper;
 
 import com.teamagam.gimelgimel.app.GGApplication;
 import com.teamagam.gimelgimel.app.common.BackoffStrategy;
@@ -28,13 +26,13 @@ import com.teamagam.gimelgimel.app.utils.SecuredPreferenceUtil;
 public class RepeatedBackoffMessagePolling extends RepeatedBackoffTaskRunner {
 
     private static Logger sLogger = LoggerFactory.create();
-    private static HandlerThread sHandlerThread = new HandlerThread("MessagePolling");
 
     public static RepeatedBackoffMessagePolling create(GGApplication ggApplication) {
         IMessagePoller poller = createPoller(ggApplication);
         BackoffStrategy backoffStrategy = createBackoffStrategy();
 
-        return new RepeatedBackoffMessagePolling(sHandlerThread, backoffStrategy, poller,
+        return new RepeatedBackoffMessagePolling(ggApplication.getBackgroundHandler(),
+                backoffStrategy, poller,
                 ggApplication);
     }
 
@@ -52,8 +50,7 @@ public class RepeatedBackoffMessagePolling extends RepeatedBackoffTaskRunner {
         return new MessageLongPoller(RestAPI.getInstance().getMessagingAPI(), processor, spu);
     }
 
-    private static TaskRunner createThreadTaskRunner(HandlerThread handlerThread) {
-        final Handler handler = new Handler(getLooper(handlerThread));
+    private static TaskRunner createThreadTaskRunner(final Handler handler) {
         return new TaskRunner() {
             @Override
             public void runNow(Runnable task) {
@@ -72,26 +69,15 @@ public class RepeatedBackoffMessagePolling extends RepeatedBackoffTaskRunner {
         };
     }
 
-    private static Looper getLooper(HandlerThread handlerThread) {
-        Looper looper = handlerThread.getLooper();
-
-        if (looper == null) {
-            handlerThread.start();
-            looper = handlerThread.getLooper();
-        }
-
-        return looper;
-    }
-
     private IMessagePoller mMessagePoller;
     private Context mContext;
 
     private RepeatedBackoffMessagePolling(
-            HandlerThread handlerThread,
+            Handler handler,
             BackoffStrategy backoffStrategy,
             IMessagePoller poller,
             Context context) {
-        super(createThreadTaskRunner(handlerThread), backoffStrategy);
+        super(createThreadTaskRunner(handler), backoffStrategy);
         mContext = context;
         mMessagePoller = poller;
     }

--- a/app/src/main/java/com/teamagam/gimelgimel/app/view/LauncherActivity.java
+++ b/app/src/main/java/com/teamagam/gimelgimel/app/view/LauncherActivity.java
@@ -8,8 +8,6 @@ import android.content.IntentFilter;
 import android.content.pm.PackageManager;
 import android.os.Build;
 import android.os.Bundle;
-import android.os.Handler;
-import android.os.HandlerThread;
 import android.os.StrictMode;
 import android.support.v4.content.ContextCompat;
 
@@ -51,13 +49,9 @@ public class LauncherActivity extends Activity {
 
         super.onCreate(savedInstanceState);
 
-        HandlerThread ht = new HandlerThread("connectivity");
-        ht.start();
-        Handler h = new Handler(ht.getLooper());
-        getApplicationContext().registerReceiver(new NetworkChangeReceiver(),
-                new IntentFilter("android.net.conn.CONNECTIVITY_CHANGE"), null, h);
-
         mApp = (GGApplication) getApplicationContext();
+
+        registerNetworkChangedReceiver();
 
         // Update the number of application launches
         mApp.getPrefs().applyInt(R.string.pref_app_launch_times,
@@ -81,6 +75,12 @@ public class LauncherActivity extends Activity {
             requestGpsLocationUpdates();
             startMainActivity();
         }
+    }
+
+    private void registerNetworkChangedReceiver() {
+        registerReceiver(new NetworkChangeReceiver(),
+                new IntentFilter("android.net.conn.CONNECTIVITY_CHANGE"), null,
+                mApp.getBackgroundHandler());
     }
 
     @Override

--- a/app/src/main/java/com/teamagam/gimelgimel/app/view/LauncherActivity.java
+++ b/app/src/main/java/com/teamagam/gimelgimel/app/view/LauncherActivity.java
@@ -4,7 +4,6 @@ import android.Manifest;
 import android.annotation.TargetApi;
 import android.app.Activity;
 import android.content.Intent;
-import android.content.IntentFilter;
 import android.content.pm.PackageManager;
 import android.os.Build;
 import android.os.Bundle;
@@ -18,7 +17,6 @@ import com.teamagam.gimelgimel.app.common.logging.Logger;
 import com.teamagam.gimelgimel.app.common.logging.LoggerFactory;
 import com.teamagam.gimelgimel.app.control.receivers.NewLocationBroadcastReceiver;
 import com.teamagam.gimelgimel.app.control.sensors.LocationFetcher;
-import com.teamagam.gimelgimel.app.network.receivers.NetworkChangeReceiver;
 import com.teamagam.gimelgimel.app.network.services.GGMessageSender;
 
 public class LauncherActivity extends Activity {
@@ -51,8 +49,6 @@ public class LauncherActivity extends Activity {
 
         mApp = (GGApplication) getApplicationContext();
 
-        registerNetworkChangedReceiver();
-
         // Update the number of application launches
         mApp.getPrefs().applyInt(R.string.pref_app_launch_times,
                 mApp.getPrefs().getInt(R.string.pref_app_launch_times, 0) + 1);
@@ -75,12 +71,6 @@ public class LauncherActivity extends Activity {
             requestGpsLocationUpdates();
             startMainActivity();
         }
-    }
-
-    private void registerNetworkChangedReceiver() {
-        registerReceiver(new NetworkChangeReceiver(),
-                new IntentFilter("android.net.conn.CONNECTIVITY_CHANGE"), null,
-                mApp.getBackgroundHandler());
     }
 
     @Override

--- a/app/src/main/java/com/teamagam/gimelgimel/app/view/MainActivity.java
+++ b/app/src/main/java/com/teamagam/gimelgimel/app/view/MainActivity.java
@@ -280,7 +280,7 @@ public class MainActivity extends BaseActivity<GGApplication>
                 "android.net.conn.CONNECTIVITY_CHANGE");
 
         registerReceiver(mNetworkChangeReceiver, connectivityChangedIntentFilter, null,
-                mApp.getBackgroundHandler());
+                mApp.getSharedBackgroundHandler());
     }
 
     private void unregisterReceivers() {


### PR DESCRIPTION
This one was weird as it happened more frequesnt on the release version.
NetworkChangedReceiver was registed statically (through the manifest). Receivers that are registered statically are executed on the main thread, and they're released as soon as their onReceive method is handled.
Both these issues were fixed as the receiver is now registered dynamically and with a dedicated handler, to run its work off the ui thread.
Since two components were using such background handlers, I made them both use the same one.
