### PR TITLE
Changed the default behaviour of MainActivity's back button.

### DIFF
--- a/app/src/main/java/com/teamagam/gimelgimel/app/view/MainActivity.java
+++ b/app/src/main/java/com/teamagam/gimelgimel/app/view/MainActivity.java
@@ -104,6 +104,13 @@ public class MainActivity extends BaseActivity<GGApplication>
     }
 
     @Override
+    public void onBackPressed() {
+        sLogger.userInteraction("Back key pressed");
+        //"Minimizes" application without forcing the activity to be destroyed
+        moveTaskToBack(true);
+    }
+
+    @Override
     protected void onResume() {
         super.onResume();
 


### PR DESCRIPTION
Instead of forcing Android to destroy the activity, it'll push the activity to the back-stack, causing it to be stopped and not destroyed.
The activity can still be destroyed if the system needs to free resources, but it'll not be the default behaviour.
