### PR TITLE
App will fetch entire messages on every start-up

### DIFF
--- a/app/src/debug/java/com/teamagam/gimelgimel/app/utils/Constants.java
+++ b/app/src/debug/java/com/teamagam/gimelgimel/app/utils/Constants.java
@@ -30,7 +30,7 @@ public class Constants {
     //Message Long polling exponential backoff configuration
     public static final int POLLING_EXP_BACKOFF_BASE_INTERVAL_MILLIS = 50;
     public static final int POLLING_EXP_BACKOFF_MULTIPLIER = 2;
-    public static final int POLLING_EXP_BACKOFF_MAX_BACKOFF_MILLIS = 60 * 1000;
+    public static final int POLLING_EXP_BACKOFF_MAX_BACKOFF_MILLIS = 5 * 1000;
 
     // Log4jDiskLogger
     public static final String LOG_FILE_NAME_SUFFIX = "log.txt";

--- a/app/src/main/java/com/teamagam/gimelgimel/app/GGApplication.java
+++ b/app/src/main/java/com/teamagam/gimelgimel/app/GGApplication.java
@@ -79,69 +79,6 @@ public class GGApplication extends Application {
         return mPrefs;
     }
 
-    private void loadDefaultXmlValues(int xmlId) {
-        PreferenceManager.setDefaultValues(this, xmlId, false);
-    }
-
-    private void init() {
-        compositeModels();
-        compositeViewModels();
-
-        mGpsStatusBroadcastReceiver = new GpsStatusBroadcastReceiver(this);
-
-        mSharedBackgroundHandler = createHandlerThread("backgroundThread");
-        mMessagingHandler = createHandlerThread("messaging");
-
-        mRepeatedBackoffMessagePolling = RepeatedBackoffMessagePolling.create(this);
-
-        LoggerFactory.init(this);
-
-        // Initialize the fresco plugin.
-        // Should be here instead of each activity
-        Fresco.initialize(this);
-    }
-
-    private Handler createHandlerThread(String name) {
-        HandlerThread ht = new HandlerThread(name);
-        ht.start();
-        return new Handler(ht.getLooper());
-    }
-
-    private void compositeViewModels() {
-        mMessagesViewModel = new MessagesViewModel(mMessagesModel, mSelectedMessageModel,
-                mMessagesReadStatusModel);
-        mContainerMessagesViewModel = new ContainerMessagesViewModel(mSelectedMessageModel,
-                mMessagesReadStatusModel, mMessagesModel);
-        mImageMessageDetailViewModel = new ImageMessageDetailViewModel(mSelectedMessageModel);
-        mTextMessageDetailViewModel = new TextMessageDetailViewModel(mSelectedMessageModel);
-        mLatLongMessageDetailViewModel = new GeoMessageDetailViewModel(mSelectedMessageModel);
-
-        EntityMessageSymbolizer symbolizer = new EntityMessageSymbolizer(this);
-        mMessageMapEntitiesViewModel = new MessageMapEntitiesViewModel(mSelectedMessageModel,
-                symbolizer);
-        mUserLocationViewModel = new UsersLocationViewModel(symbolizer);
-    }
-
-    private void compositeModels() {
-        mMessagesModel = new InMemoryMessagesModel();
-        mMessagesReadStatusModel = new InMemoryMessagesReadStatusModel();
-        mSelectedMessageModel = new InMemorySelectedMessageModel();
-    }
-
-    private void registerBroadcasts() {
-        LocalBroadcastManager localBroadcastManager = LocalBroadcastManager.getInstance(this);
-        IntentFilter intentFilter = new IntentFilter(
-                GpsStatusBroadcastReceiver.BROADCAST_GPS_STATUS_ACTION);
-
-        localBroadcastManager.registerReceiver(mGpsStatusBroadcastReceiver, intentFilter);
-    }
-
-    private void unregisterBroadcasts() {
-        LocalBroadcastManager localBroadcastManager = LocalBroadcastManager.getInstance(this);
-
-        localBroadcastManager.unregisterReceiver(mGpsStatusBroadcastReceiver);
-    }
-
     public RepeatedBackoffTaskRunner getRepeatedBackoffMessagePolling() {
         return mRepeatedBackoffMessagePolling;
     }
@@ -184,5 +121,74 @@ public class GGApplication extends Application {
 
     public Handler getMessagingHandler(){
         return mMessagingHandler;
+    }
+
+    private void loadDefaultXmlValues(int xmlId) {
+        PreferenceManager.setDefaultValues(this, xmlId, false);
+    }
+
+    private void init() {
+        compositeModels();
+        compositeViewModels();
+
+        mGpsStatusBroadcastReceiver = new GpsStatusBroadcastReceiver(this);
+
+        mSharedBackgroundHandler = createHandlerThread("backgroundThread");
+        mMessagingHandler = createHandlerThread("messaging");
+
+        resetMessageSynchronizationTime();
+        mRepeatedBackoffMessagePolling = RepeatedBackoffMessagePolling.create(this);
+
+        LoggerFactory.init(this);
+
+        // Initialize the fresco plugin.
+        // Should be here instead of each activity
+        Fresco.initialize(this);
+    }
+
+
+    private void resetMessageSynchronizationTime() {
+        getPrefs().applyLong(R.string.pref_latest_received_message_date_in_ms, 0);
+    }
+
+    private Handler createHandlerThread(String name) {
+        HandlerThread ht = new HandlerThread(name);
+        ht.start();
+        return new Handler(ht.getLooper());
+    }
+
+    private void compositeViewModels() {
+        mMessagesViewModel = new MessagesViewModel(mMessagesModel, mSelectedMessageModel,
+                mMessagesReadStatusModel);
+        mContainerMessagesViewModel = new ContainerMessagesViewModel(mSelectedMessageModel,
+                mMessagesReadStatusModel, mMessagesModel);
+        mImageMessageDetailViewModel = new ImageMessageDetailViewModel(mSelectedMessageModel);
+        mTextMessageDetailViewModel = new TextMessageDetailViewModel(mSelectedMessageModel);
+        mLatLongMessageDetailViewModel = new GeoMessageDetailViewModel(mSelectedMessageModel);
+
+        EntityMessageSymbolizer symbolizer = new EntityMessageSymbolizer(this);
+        mMessageMapEntitiesViewModel = new MessageMapEntitiesViewModel(mSelectedMessageModel,
+                symbolizer);
+        mUserLocationViewModel = new UsersLocationViewModel(symbolizer);
+    }
+
+    private void compositeModels() {
+        mMessagesModel = new InMemoryMessagesModel();
+        mMessagesReadStatusModel = new InMemoryMessagesReadStatusModel();
+        mSelectedMessageModel = new InMemorySelectedMessageModel();
+    }
+
+    private void registerBroadcasts() {
+        LocalBroadcastManager localBroadcastManager = LocalBroadcastManager.getInstance(this);
+        IntentFilter intentFilter = new IntentFilter(
+                GpsStatusBroadcastReceiver.BROADCAST_GPS_STATUS_ACTION);
+
+        localBroadcastManager.registerReceiver(mGpsStatusBroadcastReceiver, intentFilter);
+    }
+
+    private void unregisterBroadcasts() {
+        LocalBroadcastManager localBroadcastManager = LocalBroadcastManager.getInstance(this);
+
+        localBroadcastManager.unregisterReceiver(mGpsStatusBroadcastReceiver);
     }
 }

--- a/app/src/main/java/com/teamagam/gimelgimel/app/network/services/message_polling/polling/MessageLongPoller.java
+++ b/app/src/main/java/com/teamagam/gimelgimel/app/network/services/message_polling/polling/MessageLongPoller.java
@@ -86,18 +86,8 @@ public class MessageLongPoller implements IMessagePoller {
      */
     private Collection<Message> getMessagesSynchronously(long minDateFilter)
             throws ConnectionException {
-        Call<List<Message>> messagesCall = buildMessageRequestCall(minDateFilter);
+        Call<List<Message>> messagesCall = mMessagingApi.getMessagesFromDate(minDateFilter);
         return executeCall(messagesCall);
-    }
-
-    private Call<List<Message>> buildMessageRequestCall(long minDateFilter) {
-        Call<List<Message>> messagesCall;
-        if (minDateFilter == 0) {
-            messagesCall = mMessagingApi.getMessages();
-        } else {
-            messagesCall = mMessagingApi.getMessagesFromDate(minDateFilter);
-        }
-        return messagesCall;
     }
 
     private List<Message> executeCall(Call<List<Message>> messagesCall) throws ConnectionException {

--- a/app/src/release/java/com/teamagam/gimelgimel/app/utils/Constants.java
+++ b/app/src/release/java/com/teamagam/gimelgimel/app/utils/Constants.java
@@ -30,7 +30,7 @@ public class Constants {
     //Message Long polling exponential backoff configuration
     public static final int POLLING_EXP_BACKOFF_BASE_INTERVAL_MILLIS = 50;
     public static final int POLLING_EXP_BACKOFF_MULTIPLIER = 2;
-    public static final int POLLING_EXP_BACKOFF_MAX_BACKOFF_MILLIS = 60 * 1000;
+    public static final int POLLING_EXP_BACKOFF_MAX_BACKOFF_MILLIS = 5 * 1000;
 
     // Log4jDiskLogger
     public static final String LOG_FILE_NAME_SUFFIX = "log.txt";

--- a/app/src/test/java/com/teamagam/gimelgimel/app/network/services/message_polling/MessageLongPollerTest.java
+++ b/app/src/test/java/com/teamagam/gimelgimel/app/network/services/message_polling/MessageLongPollerTest.java
@@ -68,7 +68,7 @@ public class MessageLongPollerTest {
     public void testPoll_onBadConnection_shouldThrowConnectionException() throws Exception {
         //Arrange
         when(mCallListMessagesMock.execute()).thenThrow(IOException.class);
-        when(mGGMessagingAPIMock.getMessages()).thenReturn(mCallListMessagesMock);
+        when(mGGMessagingAPIMock.getMessagesFromDate(0)).thenReturn(mCallListMessagesMock);
 
         //Act
         mMessagePoller.poll();


### PR DESCRIPTION
Message synchronization time preference is initialized with zero on app initialization (allows us to receive all the messages since the beginning of time).
 It is true that we can get rid of the preference and use an in-memory variable to hold the synchronization time, but we want the previous behaviour after we get local DB running.
Polling messages always uses "fromDate" route.

 Updated constants:
 Maximum backoff time for message polling changed from 60 seconds to 5 seconds.
