### PR TITLE
task/sensor_panel/refactoring_interactors

### DIFF
--- a/domain/src/main/java/com/teamagam/gimelgimel/domain/base/interactors/BaseDataInteractor.java
+++ b/domain/src/main/java/com/teamagam/gimelgimel/domain/base/interactors/BaseDataInteractor.java
@@ -2,7 +2,7 @@ package com.teamagam.gimelgimel.domain.base.interactors;
 
 import com.teamagam.gimelgimel.domain.base.executor.ThreadExecutor;
 
-abstract class BaseDataInteractor extends BaseInteractor {
+public abstract class BaseDataInteractor extends BaseInteractor {
 
     private final ThreadExecutor mThreadExecutor;
 

--- a/domain/src/main/java/com/teamagam/gimelgimel/domain/base/interactors/BaseDataInteractor.java
+++ b/domain/src/main/java/com/teamagam/gimelgimel/domain/base/interactors/BaseDataInteractor.java
@@ -1,0 +1,22 @@
+package com.teamagam.gimelgimel.domain.base.interactors;
+
+import com.teamagam.gimelgimel.domain.base.executor.ThreadExecutor;
+
+abstract class BaseDataInteractor extends BaseInteractor {
+
+    private final ThreadExecutor mThreadExecutor;
+
+    public BaseDataInteractor(
+            ThreadExecutor threadExecutor) {
+        mThreadExecutor = threadExecutor;
+    }
+
+    @Override
+    protected final Iterable<SubscriptionRequest> buildSubscriptionRequests() {
+        return buildSubscriptionRequests(
+                new DataSubscriptionRequest.SubscriptionRequestFactory(mThreadExecutor));
+    }
+
+    abstract Iterable<SubscriptionRequest> buildSubscriptionRequests(
+            DataSubscriptionRequest.SubscriptionRequestFactory factory);
+}

--- a/domain/src/main/java/com/teamagam/gimelgimel/domain/base/interactors/BaseDisplayInteractor.java
+++ b/domain/src/main/java/com/teamagam/gimelgimel/domain/base/interactors/BaseDisplayInteractor.java
@@ -1,0 +1,27 @@
+package com.teamagam.gimelgimel.domain.base.interactors;
+
+import com.teamagam.gimelgimel.domain.base.executor.PostExecutionThread;
+import com.teamagam.gimelgimel.domain.base.executor.ThreadExecutor;
+
+public abstract class BaseDisplayInteractor extends BaseInteractor {
+
+    private final ThreadExecutor mThreadExecutor;
+    private final PostExecutionThread mPostExecutionThread;
+
+    public BaseDisplayInteractor(
+            ThreadExecutor threadExecutor,
+            PostExecutionThread postExecutionThread) {
+        mThreadExecutor = threadExecutor;
+        mPostExecutionThread = postExecutionThread;
+    }
+
+    @Override
+    protected final Iterable<SubscriptionRequest> buildSubscriptionRequests() {
+        return buildSubscriptionRequests(
+                new DisplaySubscriptionRequest.DisplaySubscriptionRequestFactory(mThreadExecutor,
+                        mPostExecutionThread));
+    }
+
+    protected abstract Iterable<SubscriptionRequest> buildSubscriptionRequests(
+            DisplaySubscriptionRequest.DisplaySubscriptionRequestFactory factory);
+}

--- a/domain/src/main/java/com/teamagam/gimelgimel/domain/base/interactors/BaseInteractor.java
+++ b/domain/src/main/java/com/teamagam/gimelgimel/domain/base/interactors/BaseInteractor.java
@@ -1,36 +1,21 @@
 package com.teamagam.gimelgimel.domain.base.interactors;
 
-import com.teamagam.gimelgimel.domain.base.executor.PostExecutionThread;
-import com.teamagam.gimelgimel.domain.base.executor.ThreadExecutor;
-import com.teamagam.gimelgimel.domain.base.subscribers.SimpleSubscriber;
-
 import java.util.ArrayList;
 import java.util.Collection;
 
-import rx.Observable;
-import rx.Subscriber;
 import rx.Subscription;
-import rx.functions.Action1;
 
 public abstract class BaseInteractor implements Interactor {
 
-    private final ThreadExecutor mThreadExecutor;
-
-    private final PostExecutionThread mPostExecutionThread;
-
     private final Collection<Subscription> mSubscriptions;
 
-    public BaseInteractor(
-            ThreadExecutor threadExecutor,
-            PostExecutionThread postExecutionThread) {
-        mThreadExecutor = threadExecutor;
-        mPostExecutionThread = postExecutionThread;
+    public BaseInteractor() {
         mSubscriptions = new ArrayList<>();
     }
 
 
     @Override
-    public void execute() {
+    public final void execute() {
         Iterable<SubscriptionRequest> subscriptionRequests = buildSubscriptionRequests();
         for (SubscriptionRequest se : subscriptionRequests) {
             subscribe(se);
@@ -38,7 +23,7 @@ public abstract class BaseInteractor implements Interactor {
     }
 
     @Override
-    public void unsubscribe() {
+    public final void unsubscribe() {
         for (Subscription sub : mSubscriptions) {
             if (sub != null && !sub.isUnsubscribed()) {
                 sub.unsubscribe();
@@ -49,48 +34,11 @@ public abstract class BaseInteractor implements Interactor {
     protected abstract Iterable<SubscriptionRequest> buildSubscriptionRequests();
 
     private void subscribe(SubscriptionRequest se) {
-        Subscription subscription = se.subscribe(mThreadExecutor, mPostExecutionThread);
+        Subscription subscription = se.subscribe();
         mSubscriptions.add(subscription);
     }
 
-    protected static class SubscriptionRequest<T> {
-
-        private Observable<T> mObservable;
-        private Subscriber<T> mSubscriber;
-
-        protected SubscriptionRequest(Observable<T> observable) {
-            mObservable = observable;
-        }
-
-        protected SubscriptionRequest(Observable<T> observable, Subscriber<T> subscriber) {
-            mObservable = observable;
-            mSubscriber = subscriber;
-        }
-
-        protected SubscriptionRequest(Observable<T> observable, Action1<T> subscriberOnNext) {
-            this(observable);
-            mSubscriber = new SimpleSubscriber<T>() {
-                @Override
-                public void onNext(T o) {
-                    subscriberOnNext.call(o);
-                }
-            };
-        }
-
-        private Subscription subscribe(ThreadExecutor threadExecutor,
-                                       PostExecutionThread postExecutionThread) {
-            Subscription subscription;
-
-            Observable<T> obs = mObservable.subscribeOn(threadExecutor.getScheduler());
-            if (mSubscriber != null) {
-                subscription = obs.subscribe();
-            } else {
-                subscription = obs
-                        .observeOn(postExecutionThread.getScheduler())
-                        .subscribe(mSubscriber);
-            }
-
-            return subscription;
-        }
+    protected interface SubscriptionRequest {
+        Subscription subscribe();
     }
 }

--- a/domain/src/main/java/com/teamagam/gimelgimel/domain/base/interactors/BaseInteractor.java
+++ b/domain/src/main/java/com/teamagam/gimelgimel/domain/base/interactors/BaseInteractor.java
@@ -1,0 +1,96 @@
+package com.teamagam.gimelgimel.domain.base.interactors;
+
+import com.teamagam.gimelgimel.domain.base.executor.PostExecutionThread;
+import com.teamagam.gimelgimel.domain.base.executor.ThreadExecutor;
+import com.teamagam.gimelgimel.domain.base.subscribers.SimpleSubscriber;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+import rx.Observable;
+import rx.Subscriber;
+import rx.Subscription;
+import rx.functions.Action1;
+
+public abstract class BaseInteractor implements Interactor {
+
+    private final ThreadExecutor mThreadExecutor;
+
+    private final PostExecutionThread mPostExecutionThread;
+
+    private final Collection<Subscription> mSubscriptions;
+
+    public BaseInteractor(
+            ThreadExecutor threadExecutor,
+            PostExecutionThread postExecutionThread) {
+        mThreadExecutor = threadExecutor;
+        mPostExecutionThread = postExecutionThread;
+        mSubscriptions = new ArrayList<>();
+    }
+
+
+    @Override
+    public void execute() {
+        Iterable<SubscriptionRequest> subscriptionRequests = buildSubscriptionRequests();
+        for (SubscriptionRequest se : subscriptionRequests) {
+            subscribe(se);
+        }
+    }
+
+    @Override
+    public void unsubscribe() {
+        for (Subscription sub : mSubscriptions) {
+            if (sub != null && !sub.isUnsubscribed()) {
+                sub.unsubscribe();
+            }
+        }
+    }
+
+    protected abstract Iterable<SubscriptionRequest> buildSubscriptionRequests();
+
+    private void subscribe(SubscriptionRequest se) {
+        Subscription subscription = se.subscribe(mThreadExecutor, mPostExecutionThread);
+        mSubscriptions.add(subscription);
+    }
+
+    protected static class SubscriptionRequest<T> {
+
+        private Observable<T> mObservable;
+        private Subscriber<T> mSubscriber;
+
+        protected SubscriptionRequest(Observable<T> observable) {
+            mObservable = observable;
+        }
+
+        protected SubscriptionRequest(Observable<T> observable, Subscriber<T> subscriber) {
+            mObservable = observable;
+            mSubscriber = subscriber;
+        }
+
+        protected SubscriptionRequest(Observable<T> observable, Action1<T> subscriberOnNext) {
+            this(observable);
+            mSubscriber = new SimpleSubscriber<T>() {
+                @Override
+                public void onNext(T o) {
+                    subscriberOnNext.call(o);
+                }
+            };
+        }
+
+        private Subscription subscribe(ThreadExecutor threadExecutor,
+                                       PostExecutionThread postExecutionThread) {
+            Subscription subscription;
+
+            Observable<T> obs = mObservable.subscribeOn(threadExecutor.getScheduler());
+            if (mSubscriber != null) {
+                subscription = obs.subscribe();
+            } else {
+                subscription = obs
+                        .observeOn(postExecutionThread.getScheduler())
+                        .subscribe(mSubscriber);
+            }
+
+            return subscription;
+        }
+    }
+}

--- a/domain/src/main/java/com/teamagam/gimelgimel/domain/base/interactors/BaseInteractor.java
+++ b/domain/src/main/java/com/teamagam/gimelgimel/domain/base/interactors/BaseInteractor.java
@@ -5,14 +5,13 @@ import java.util.Collection;
 
 import rx.Subscription;
 
-public abstract class BaseInteractor implements Interactor {
+abstract class BaseInteractor implements Interactor {
 
     private final Collection<Subscription> mSubscriptions;
 
-    public BaseInteractor() {
+    BaseInteractor() {
         mSubscriptions = new ArrayList<>();
     }
-
 
     @Override
     public final void execute() {

--- a/domain/src/main/java/com/teamagam/gimelgimel/domain/base/interactors/BaseSingleDisplayInteractor.java
+++ b/domain/src/main/java/com/teamagam/gimelgimel/domain/base/interactors/BaseSingleDisplayInteractor.java
@@ -1,0 +1,24 @@
+package com.teamagam.gimelgimel.domain.base.interactors;
+
+import com.teamagam.gimelgimel.domain.base.executor.PostExecutionThread;
+import com.teamagam.gimelgimel.domain.base.executor.ThreadExecutor;
+
+import java.util.Collections;
+
+public abstract class BaseSingleDisplayInteractor extends BaseDisplayInteractor {
+
+    public BaseSingleDisplayInteractor(
+            ThreadExecutor threadExecutor,
+            PostExecutionThread postExecutionThread) {
+        super(threadExecutor, postExecutionThread);
+    }
+
+    @Override
+    protected final Iterable<SubscriptionRequest> buildSubscriptionRequests(
+            DisplaySubscriptionRequest.DisplaySubscriptionRequestFactory factory) {
+        return Collections.singletonList(buildSubscriptionRequest(factory));
+    }
+
+    protected abstract SubscriptionRequest buildSubscriptionRequest(
+            DisplaySubscriptionRequest.DisplaySubscriptionRequestFactory factory);
+}

--- a/domain/src/main/java/com/teamagam/gimelgimel/domain/base/interactors/DataSubscriptionRequest.java
+++ b/domain/src/main/java/com/teamagam/gimelgimel/domain/base/interactors/DataSubscriptionRequest.java
@@ -5,16 +5,15 @@ import com.teamagam.gimelgimel.domain.base.executor.ThreadExecutor;
 import rx.Observable;
 import rx.Subscription;
 
-public class DataSubscriptionRequest<T> implements BaseInteractor.SubscriptionRequest {
+class DataSubscriptionRequest<T> implements BaseInteractor.SubscriptionRequest {
 
-    protected Observable<T> mObservable;
-    protected ThreadExecutor mThreadExecutor;
+    private final Observable<T> mObservable;
+    private final ThreadExecutor mThreadExecutor;
 
-    protected DataSubscriptionRequest(ThreadExecutor threadExecutor, Observable<T> observable) {
+    private DataSubscriptionRequest(ThreadExecutor threadExecutor, Observable<T> observable) {
         mThreadExecutor = threadExecutor;
         mObservable = observable;
     }
-
 
     public Subscription subscribe() {
         return mObservable
@@ -22,16 +21,16 @@ public class DataSubscriptionRequest<T> implements BaseInteractor.SubscriptionRe
                 .subscribe();
     }
 
-    public static class SubscriptionRequestFactory {
+    static class SubscriptionRequestFactory {
         private final ThreadExecutor mThreadExecutor;
 
-        public SubscriptionRequestFactory(
+        SubscriptionRequestFactory(
                 ThreadExecutor threadExecutor) {
             mThreadExecutor = threadExecutor;
         }
 
-        public BaseInteractor.SubscriptionRequest create(Observable observable) {
-            return new DataSubscriptionRequest(mThreadExecutor, observable);
+        public <T> BaseInteractor.SubscriptionRequest create(Observable<T> observable) {
+            return new DataSubscriptionRequest<>(mThreadExecutor, observable);
         }
     }
 }

--- a/domain/src/main/java/com/teamagam/gimelgimel/domain/base/interactors/DataSubscriptionRequest.java
+++ b/domain/src/main/java/com/teamagam/gimelgimel/domain/base/interactors/DataSubscriptionRequest.java
@@ -1,0 +1,37 @@
+package com.teamagam.gimelgimel.domain.base.interactors;
+
+import com.teamagam.gimelgimel.domain.base.executor.ThreadExecutor;
+
+import rx.Observable;
+import rx.Subscription;
+
+public class DataSubscriptionRequest<T> implements BaseInteractor.SubscriptionRequest {
+
+    protected Observable<T> mObservable;
+    protected ThreadExecutor mThreadExecutor;
+
+    protected DataSubscriptionRequest(ThreadExecutor threadExecutor, Observable<T> observable) {
+        mThreadExecutor = threadExecutor;
+        mObservable = observable;
+    }
+
+
+    public Subscription subscribe() {
+        return mObservable
+                .subscribeOn(mThreadExecutor.getScheduler())
+                .subscribe();
+    }
+
+    public static class SubscriptionRequestFactory {
+        private final ThreadExecutor mThreadExecutor;
+
+        public SubscriptionRequestFactory(
+                ThreadExecutor threadExecutor) {
+            mThreadExecutor = threadExecutor;
+        }
+
+        public BaseInteractor.SubscriptionRequest create(Observable observable) {
+            return new DataSubscriptionRequest(mThreadExecutor, observable);
+        }
+    }
+}

--- a/domain/src/main/java/com/teamagam/gimelgimel/domain/base/interactors/DisplaySubscriptionRequest.java
+++ b/domain/src/main/java/com/teamagam/gimelgimel/domain/base/interactors/DisplaySubscriptionRequest.java
@@ -1,0 +1,64 @@
+package com.teamagam.gimelgimel.domain.base.interactors;
+
+import com.teamagam.gimelgimel.domain.base.executor.PostExecutionThread;
+import com.teamagam.gimelgimel.domain.base.executor.ThreadExecutor;
+import com.teamagam.gimelgimel.domain.base.subscribers.SimpleSubscriber;
+
+import rx.Observable;
+import rx.Subscriber;
+import rx.Subscription;
+import rx.functions.Action1;
+
+public class DisplaySubscriptionRequest<T> extends DataSubscriptionRequest<T> {
+
+    private final Subscriber<T> mSubscriber;
+    private final PostExecutionThread mPostExecutionThread;
+
+
+    protected DisplaySubscriptionRequest(ThreadExecutor threadExecutor,
+                                         PostExecutionThread postExecutionThread,
+                                         Observable<T> observer,
+                                         Subscriber<T> subscriber) {
+        super(threadExecutor, observer);
+        mPostExecutionThread = postExecutionThread;
+        mSubscriber = subscriber;
+    }
+
+    @Override
+    public Subscription subscribe() {
+        return mObservable
+                .subscribeOn(mThreadExecutor.getScheduler())
+                .observeOn(mPostExecutionThread.getScheduler())
+                .subscribe(mSubscriber);
+    }
+
+    public static class DisplaySubscriptionRequestFactory {
+        private final ThreadExecutor mThreadExecutor;
+        private final PostExecutionThread mPostExecutionThread;
+
+        public DisplaySubscriptionRequestFactory(
+                ThreadExecutor threadExecutor,
+                PostExecutionThread postExecutionThread) {
+            mThreadExecutor = threadExecutor;
+            mPostExecutionThread = postExecutionThread;
+        }
+
+        public <T> DisplaySubscriptionRequest create(Observable<T> observable,
+                                                 Subscriber<T> subscriber) {
+            return new DisplaySubscriptionRequest(mThreadExecutor, mPostExecutionThread, observable,
+                    subscriber);
+        }
+
+        public <T> DisplaySubscriptionRequest create(Observable<T> observable,
+                                                 Action1<T> subscriberOnNext) {
+            Subscriber<T> subscriber = new SimpleSubscriber<T>() {
+                @Override
+                public void onNext(T o) {
+                    subscriberOnNext.call(o);
+                }
+            };
+            return new DisplaySubscriptionRequest(mThreadExecutor, mPostExecutionThread, observable,
+                    subscriber);
+        }
+    }
+}

--- a/domain/src/main/java/com/teamagam/gimelgimel/domain/base/interactors/DisplaySubscriptionRequest.java
+++ b/domain/src/main/java/com/teamagam/gimelgimel/domain/base/interactors/DisplaySubscriptionRequest.java
@@ -9,18 +9,20 @@ import rx.Subscriber;
 import rx.Subscription;
 import rx.functions.Action1;
 
-public class DisplaySubscriptionRequest<T> extends DataSubscriptionRequest<T> {
+public class DisplaySubscriptionRequest<T> implements BaseInteractor.SubscriptionRequest {
 
-    private final Subscriber<T> mSubscriber;
+    private final ThreadExecutor mThreadExecutor;
     private final PostExecutionThread mPostExecutionThread;
+    private final Observable<T> mObservable;
+    private final Subscriber<T> mSubscriber;
 
-
-    protected DisplaySubscriptionRequest(ThreadExecutor threadExecutor,
-                                         PostExecutionThread postExecutionThread,
-                                         Observable<T> observer,
-                                         Subscriber<T> subscriber) {
-        super(threadExecutor, observer);
+    private DisplaySubscriptionRequest(ThreadExecutor threadExecutor,
+                                       PostExecutionThread postExecutionThread,
+                                       Observable<T> observable,
+                                       Subscriber<T> subscriber) {
+        mThreadExecutor = threadExecutor;
         mPostExecutionThread = postExecutionThread;
+        mObservable = observable;
         mSubscriber = subscriber;
     }
 
@@ -36,7 +38,7 @@ public class DisplaySubscriptionRequest<T> extends DataSubscriptionRequest<T> {
         private final ThreadExecutor mThreadExecutor;
         private final PostExecutionThread mPostExecutionThread;
 
-        public DisplaySubscriptionRequestFactory(
+        DisplaySubscriptionRequestFactory(
                 ThreadExecutor threadExecutor,
                 PostExecutionThread postExecutionThread) {
             mThreadExecutor = threadExecutor;
@@ -44,21 +46,21 @@ public class DisplaySubscriptionRequest<T> extends DataSubscriptionRequest<T> {
         }
 
         public <T> DisplaySubscriptionRequest create(Observable<T> observable,
-                                                 Subscriber<T> subscriber) {
-            return new DisplaySubscriptionRequest(mThreadExecutor, mPostExecutionThread, observable,
-                    subscriber);
+                                                     Subscriber<T> subscriber) {
+            return new DisplaySubscriptionRequest<>(mThreadExecutor, mPostExecutionThread,
+                    observable, subscriber);
         }
 
         public <T> DisplaySubscriptionRequest create(Observable<T> observable,
-                                                 Action1<T> subscriberOnNext) {
+                                                     Action1<T> subscriberOnNext) {
             Subscriber<T> subscriber = new SimpleSubscriber<T>() {
                 @Override
                 public void onNext(T o) {
                     subscriberOnNext.call(o);
                 }
             };
-            return new DisplaySubscriptionRequest(mThreadExecutor, mPostExecutionThread, observable,
-                    subscriber);
+            return new DisplaySubscriptionRequest<>(mThreadExecutor, mPostExecutionThread,
+                    observable, subscriber);
         }
     }
 }

--- a/domain/src/main/java/com/teamagam/gimelgimel/domain/map/DisplayMapEntitiesInteractor.java
+++ b/domain/src/main/java/com/teamagam/gimelgimel/domain/map/DisplayMapEntitiesInteractor.java
@@ -4,62 +4,42 @@ import com.google.auto.factory.AutoFactory;
 import com.google.auto.factory.Provided;
 import com.teamagam.gimelgimel.domain.base.executor.PostExecutionThread;
 import com.teamagam.gimelgimel.domain.base.executor.ThreadExecutor;
-import com.teamagam.gimelgimel.domain.base.interactors.SyncInteractor;
-import com.teamagam.gimelgimel.domain.base.subscribers.SimpleSubscriber;
+import com.teamagam.gimelgimel.domain.base.interactors.BaseDisplayInteractor;
+import com.teamagam.gimelgimel.domain.base.interactors.DisplaySubscriptionRequest;
 import com.teamagam.gimelgimel.domain.map.repository.DisplayedEntitiesRepository;
 import com.teamagam.gimelgimel.domain.notifications.entity.GeoEntityNotification;
 
-import rx.Observable;
+import java.util.Collections;
 
-/**
- * Created on 11/13/2016.
- * TODO: complete text
- */
 @AutoFactory
-public class DisplayMapEntitiesInteractor extends SyncInteractor<GeoEntityNotification> {
+public class DisplayMapEntitiesInteractor extends BaseDisplayInteractor {
 
     private final DisplayedEntitiesRepository mDisplayedRepo;
+    private final Displayer mDisplayer;
 
-    protected DisplayMapEntitiesInteractor(@Provided ThreadExecutor threadExecutor,
-                                           @Provided PostExecutionThread postExecutionThread,
-                                           @Provided DisplayedEntitiesRepository mapRepo,
-                                           Displayer displayer) {
-        super(threadExecutor, postExecutionThread, new ShowDisplayedEntitySubscriber(displayer));
+    protected DisplayMapEntitiesInteractor(
+            @Provided ThreadExecutor threadExecutor,
+            @Provided PostExecutionThread postExecutionThread,
+            @Provided DisplayedEntitiesRepository mapRepo,
+            Displayer displayer) {
+        super(threadExecutor, postExecutionThread);
         mDisplayedRepo = mapRepo;
+        mDisplayer = displayer;
     }
 
     @Override
-    protected Observable<GeoEntityNotification> buildUseCaseObservable() {
-        return mDisplayedRepo.getDisplayedGeoEntitiesObservable()
-                .flatMapIterable(entities -> entities)
-                .map(GeoEntityNotification::createAdd)
-                .concatWith(mDisplayedRepo.getSyncEntitiesObservable());
-
-    }
-
-    private static class ShowDisplayedEntitySubscriber extends SimpleSubscriber<GeoEntityNotification> {
-
-        private Displayer mDisplayer;
-
-        private ShowDisplayedEntitySubscriber(Displayer displayer) {
-            mDisplayer = displayer;
-        }
-
-        @Override
-        public void onNext(GeoEntityNotification geoEntityNotification) {
-            mDisplayer.displayEntityNotification(geoEntityNotification);
-        }
-
-        @Override
-        public void onError(Throwable e) {
-//            super.onError(e);
-//            sLogger.e("point next error: ", e);
-        }
-
+    protected Iterable<SubscriptionRequest> buildSubscriptionRequests(
+            DisplaySubscriptionRequest.DisplaySubscriptionRequestFactory factory) {
+        return Collections.singletonList(
+                factory.create(
+                        mDisplayedRepo.getDisplayedGeoEntitiesObservable()
+                                .flatMapIterable(entities -> entities)
+                                .map(GeoEntityNotification::createAdd)
+                                .concatWith(mDisplayedRepo.getSyncEntitiesObservable()),
+                        mDisplayer::displayEntityNotification));
     }
 
     public interface Displayer {
         void displayEntityNotification(GeoEntityNotification geoEntity);
     }
-
 }

--- a/domain/src/main/java/com/teamagam/gimelgimel/domain/map/DisplayMapEntitiesInteractor.java
+++ b/domain/src/main/java/com/teamagam/gimelgimel/domain/map/DisplayMapEntitiesInteractor.java
@@ -4,15 +4,13 @@ import com.google.auto.factory.AutoFactory;
 import com.google.auto.factory.Provided;
 import com.teamagam.gimelgimel.domain.base.executor.PostExecutionThread;
 import com.teamagam.gimelgimel.domain.base.executor.ThreadExecutor;
-import com.teamagam.gimelgimel.domain.base.interactors.BaseDisplayInteractor;
+import com.teamagam.gimelgimel.domain.base.interactors.BaseSingleDisplayInteractor;
 import com.teamagam.gimelgimel.domain.base.interactors.DisplaySubscriptionRequest;
 import com.teamagam.gimelgimel.domain.map.repository.DisplayedEntitiesRepository;
 import com.teamagam.gimelgimel.domain.notifications.entity.GeoEntityNotification;
 
-import java.util.Collections;
-
 @AutoFactory
-public class DisplayMapEntitiesInteractor extends BaseDisplayInteractor {
+public class DisplayMapEntitiesInteractor extends BaseSingleDisplayInteractor {
 
     private final DisplayedEntitiesRepository mDisplayedRepo;
     private final Displayer mDisplayer;
@@ -28,15 +26,14 @@ public class DisplayMapEntitiesInteractor extends BaseDisplayInteractor {
     }
 
     @Override
-    protected Iterable<SubscriptionRequest> buildSubscriptionRequests(
+    protected SubscriptionRequest buildSubscriptionRequest(
             DisplaySubscriptionRequest.DisplaySubscriptionRequestFactory factory) {
-        return Collections.singletonList(
-                factory.create(
-                        mDisplayedRepo.getDisplayedGeoEntitiesObservable()
-                                .flatMapIterable(entities -> entities)
-                                .map(GeoEntityNotification::createAdd)
-                                .concatWith(mDisplayedRepo.getSyncEntitiesObservable()),
-                        mDisplayer::displayEntityNotification));
+        return factory.create(
+                mDisplayedRepo.getDisplayedGeoEntitiesObservable()
+                        .flatMapIterable(entities -> entities)
+                        .map(GeoEntityNotification::createAdd)
+                        .concatWith(mDisplayedRepo.getSyncEntitiesObservable()),
+                mDisplayer::displayEntityNotification);
     }
 
     public interface Displayer {

--- a/domain/src/main/java/com/teamagam/gimelgimel/domain/messages/DisplayMessagesInteractor.java
+++ b/domain/src/main/java/com/teamagam/gimelgimel/domain/messages/DisplayMessagesInteractor.java
@@ -4,14 +4,15 @@ import com.google.auto.factory.AutoFactory;
 import com.google.auto.factory.Provided;
 import com.teamagam.gimelgimel.domain.base.executor.PostExecutionThread;
 import com.teamagam.gimelgimel.domain.base.executor.ThreadExecutor;
-import com.teamagam.gimelgimel.domain.base.interactors.BaseInteractor;
+import com.teamagam.gimelgimel.domain.base.interactors.BaseDisplayInteractor;
+import com.teamagam.gimelgimel.domain.base.interactors.DisplaySubscriptionRequest;
 import com.teamagam.gimelgimel.domain.messages.entity.Message;
 import com.teamagam.gimelgimel.domain.messages.repository.MessagesRepository;
 
 import java.util.Arrays;
 
 @AutoFactory
-public class DisplayMessagesInteractor extends BaseInteractor {
+public class DisplayMessagesInteractor extends BaseDisplayInteractor {
 
     private final Displayer mDisplayer;
     private final MessagesRepository mMessagesRepository;
@@ -28,17 +29,19 @@ public class DisplayMessagesInteractor extends BaseInteractor {
     }
 
     @Override
-    protected Iterable<SubscriptionRequest> buildSubscriptionRequests() {
-        SubscriptionRequest<Message> displayMessages = new SubscriptionRequest<>(
+    protected Iterable<SubscriptionRequest> buildSubscriptionRequests(
+            DisplaySubscriptionRequest.DisplaySubscriptionRequestFactory factory) {
+
+        DisplaySubscriptionRequest displayMessages = factory.create(
                 mMessagesRepository.getMessagesObservable(),
                 mDisplayer::show);
 
-        SubscriptionRequest<Message> displayRead = new SubscriptionRequest<>(
+        DisplaySubscriptionRequest displayRead = factory.create(
                 mMessagesRepository.getReadMessagesObservable(),
                 mDisplayer::read
         );
 
-        SubscriptionRequest<Message> displaySelected = new SubscriptionRequest<>(
+        DisplaySubscriptionRequest displaySelected = factory.create(
                 mMessagesRepository.getSelectedMessageObservable(),
                 mDisplayer::select);
 

--- a/domain/src/main/java/com/teamagam/gimelgimel/domain/messages/DisplayMessagesInteractor.java
+++ b/domain/src/main/java/com/teamagam/gimelgimel/domain/messages/DisplayMessagesInteractor.java
@@ -4,85 +4,47 @@ import com.google.auto.factory.AutoFactory;
 import com.google.auto.factory.Provided;
 import com.teamagam.gimelgimel.domain.base.executor.PostExecutionThread;
 import com.teamagam.gimelgimel.domain.base.executor.ThreadExecutor;
-import com.teamagam.gimelgimel.domain.base.interactors.Interactor;
-import com.teamagam.gimelgimel.domain.base.subscribers.SimpleSubscriber;
+import com.teamagam.gimelgimel.domain.base.interactors.BaseInteractor;
 import com.teamagam.gimelgimel.domain.messages.entity.Message;
 import com.teamagam.gimelgimel.domain.messages.repository.MessagesRepository;
 
-import rx.Observable;
-import rx.Subscriber;
-import rx.Subscription;
+import java.util.Arrays;
 
 @AutoFactory
-public class DisplayMessagesInteractor implements Interactor {
+public class DisplayMessagesInteractor extends BaseInteractor {
 
     private final Displayer mDisplayer;
-    private final ThreadExecutor mThreadExecutor;
-    private final PostExecutionThread mPostExecutionThread;
     private final MessagesRepository mMessagesRepository;
 
-    private Subscription mMessagesSubscription;
-    private Subscription mReadSubscription;
-    private Subscription mSelectedSubscription;
 
     protected DisplayMessagesInteractor(
             @Provided ThreadExecutor threadExecutor,
             @Provided PostExecutionThread postExecutionThread,
             @Provided MessagesRepository messagesRepository,
             Displayer displayer) {
-        mThreadExecutor = threadExecutor;
-        mPostExecutionThread = postExecutionThread;
+        super(threadExecutor, postExecutionThread);
         mMessagesRepository = messagesRepository;
         mDisplayer = displayer;
     }
 
-
     @Override
-    public void execute() {
-        mMessagesSubscription = execute(mMessagesRepository.getMessagesObservable(),
-                new SimpleSubscriber<Message>() {
-                    @Override
-                    public void onNext(Message message) {
-                        mDisplayer.show(message);
-                    }
-                });
+    protected Iterable<SubscriptionRequest> buildSubscriptionRequests() {
+        SubscriptionRequest<Message> displayMessages = new SubscriptionRequest<>(
+                mMessagesRepository.getMessagesObservable(),
+                mDisplayer::show);
 
-        mReadSubscription = execute(mMessagesRepository.getReadMessagesObservable(),
-                new SimpleSubscriber<Message>() {
-                    @Override
-                    public void onNext(Message message) {
-                        mDisplayer.read(message);
-                    }
-                });
+        SubscriptionRequest<Message> displayRead = new SubscriptionRequest<>(
+                mMessagesRepository.getReadMessagesObservable(),
+                mDisplayer::read
+        );
 
-        mSelectedSubscription = execute(mMessagesRepository.getSelectedMessageObservable(),
-                new SimpleSubscriber<Message>() {
-                    @Override
-                    public void onNext(Message message) {
-                        mDisplayer.select(message);
-                    }
-                });
+        SubscriptionRequest<Message> displaySelected = new SubscriptionRequest<>(
+                mMessagesRepository.getSelectedMessageObservable(),
+                mDisplayer::select);
+
+        return Arrays.asList(displayMessages, displayRead, displaySelected);
     }
 
-    @Override
-    public void unsubscribe() {
-        unsubscribe(mMessagesSubscription);
-        unsubscribe(mReadSubscription);
-        unsubscribe(mSelectedSubscription);
-    }
-
-    private <T> Subscription execute(Observable<T> observable, Subscriber<T> subscriber) {
-        return observable
-                .subscribeOn(mThreadExecutor.getScheduler())
-                .observeOn(mPostExecutionThread.getScheduler())
-                .subscribe(subscriber);
-    }
-
-    private void unsubscribe(Subscription subscription) {
-        if (subscription != null && !subscription.isUnsubscribed()) {
-            subscription.unsubscribe();
-        }
-    }
 
     public interface Displayer {
         void show(Message message);

--- a/domain/src/main/java/com/teamagam/gimelgimel/domain/messages/DisplaySelectedMessageInteractor.java
+++ b/domain/src/main/java/com/teamagam/gimelgimel/domain/messages/DisplaySelectedMessageInteractor.java
@@ -4,15 +4,13 @@ import com.google.auto.factory.AutoFactory;
 import com.google.auto.factory.Provided;
 import com.teamagam.gimelgimel.domain.base.executor.PostExecutionThread;
 import com.teamagam.gimelgimel.domain.base.executor.ThreadExecutor;
-import com.teamagam.gimelgimel.domain.base.interactors.BaseDisplayInteractor;
+import com.teamagam.gimelgimel.domain.base.interactors.BaseSingleDisplayInteractor;
 import com.teamagam.gimelgimel.domain.base.interactors.DisplaySubscriptionRequest;
 import com.teamagam.gimelgimel.domain.messages.entity.Message;
 import com.teamagam.gimelgimel.domain.messages.repository.MessagesRepository;
 
-import java.util.Collections;
-
 @AutoFactory
-public class DisplaySelectedMessageInteractor extends BaseDisplayInteractor {
+public class DisplaySelectedMessageInteractor extends BaseSingleDisplayInteractor {
 
 
     private final Displayer mDisplayer;
@@ -29,11 +27,11 @@ public class DisplaySelectedMessageInteractor extends BaseDisplayInteractor {
     }
 
     @Override
-    protected Iterable<SubscriptionRequest> buildSubscriptionRequests(
+    protected SubscriptionRequest buildSubscriptionRequest(
             DisplaySubscriptionRequest.DisplaySubscriptionRequestFactory factory) {
-        return Collections.singletonList(
-                factory.create(mMessagesRepository.getMessagesObservable(),
-                        mDisplayer::display));
+        return factory.create(
+                mMessagesRepository.getMessagesObservable(),
+                mDisplayer::display);
     }
 
     public interface Displayer {

--- a/domain/src/main/java/com/teamagam/gimelgimel/domain/messages/DisplaySelectedMessageInteractor.java
+++ b/domain/src/main/java/com/teamagam/gimelgimel/domain/messages/DisplaySelectedMessageInteractor.java
@@ -4,52 +4,36 @@ import com.google.auto.factory.AutoFactory;
 import com.google.auto.factory.Provided;
 import com.teamagam.gimelgimel.domain.base.executor.PostExecutionThread;
 import com.teamagam.gimelgimel.domain.base.executor.ThreadExecutor;
-import com.teamagam.gimelgimel.domain.base.interactors.Interactor;
-import com.teamagam.gimelgimel.domain.base.subscribers.SimpleSubscriber;
+import com.teamagam.gimelgimel.domain.base.interactors.BaseDisplayInteractor;
+import com.teamagam.gimelgimel.domain.base.interactors.DisplaySubscriptionRequest;
 import com.teamagam.gimelgimel.domain.messages.entity.Message;
 import com.teamagam.gimelgimel.domain.messages.repository.MessagesRepository;
 
-import rx.Subscription;
+import java.util.Collections;
 
 @AutoFactory
-public class DisplaySelectedMessageInteractor implements Interactor {
+public class DisplaySelectedMessageInteractor extends BaseDisplayInteractor {
 
 
-    private final ThreadExecutor mThreadExecutor;
-    private final PostExecutionThread mPostExecutionThread;
     private final Displayer mDisplayer;
     private MessagesRepository mMessagesRepository;
-    private Subscription mSubscription;
 
     public DisplaySelectedMessageInteractor(
             @Provided ThreadExecutor threadExecutor,
             @Provided PostExecutionThread postExecutionThread,
             @Provided MessagesRepository messagesRepository,
             Displayer displayer) {
-        mThreadExecutor = threadExecutor;
-        mPostExecutionThread = postExecutionThread;
+        super(threadExecutor, postExecutionThread);
         mMessagesRepository = messagesRepository;
         mDisplayer = displayer;
     }
 
     @Override
-    public void execute() {
-        mSubscription = mMessagesRepository.getSelectedMessageObservable()
-                .subscribeOn(mThreadExecutor.getScheduler())
-                .observeOn(mPostExecutionThread.getScheduler())
-                .subscribe(new SimpleSubscriber<Message>() {
-                    @Override
-                    public void onNext(Message message) {
-                        mDisplayer.display(message);
-                    }
-                });
-    }
-
-    @Override
-    public void unsubscribe() {
-        if (mSubscription != null && !mSubscription.isUnsubscribed()) {
-            mSubscription.unsubscribe();
-        }
+    protected Iterable<SubscriptionRequest> buildSubscriptionRequests(
+            DisplaySubscriptionRequest.DisplaySubscriptionRequestFactory factory) {
+        return Collections.singletonList(
+                factory.create(mMessagesRepository.getMessagesObservable(),
+                        mDisplayer::display));
     }
 
     public interface Displayer {

--- a/domain/src/main/java/com/teamagam/gimelgimel/domain/notifications/DisplayConnectivityStatusInteractor.java
+++ b/domain/src/main/java/com/teamagam/gimelgimel/domain/notifications/DisplayConnectivityStatusInteractor.java
@@ -2,17 +2,14 @@ package com.teamagam.gimelgimel.domain.notifications;
 
 import com.teamagam.gimelgimel.domain.base.executor.PostExecutionThread;
 import com.teamagam.gimelgimel.domain.base.executor.ThreadExecutor;
-import com.teamagam.gimelgimel.domain.base.interactors.BaseDisplayInteractor;
+import com.teamagam.gimelgimel.domain.base.interactors.BaseSingleDisplayInteractor;
 import com.teamagam.gimelgimel.domain.base.interactors.DisplaySubscriptionRequest;
 import com.teamagam.gimelgimel.domain.notifications.repository.ConnectivityStatusRepository;
 
-import java.util.Collections;
-
-class DisplayConnectivityStatusInteractor extends BaseDisplayInteractor {
+class DisplayConnectivityStatusInteractor extends BaseSingleDisplayInteractor {
 
     private final ConnectivityStatusRepository mConnectivityRepository;
     private final ConnectivityDisplayer mDisplayer;
-
 
     DisplayConnectivityStatusInteractor(
             ThreadExecutor threadExecutor,
@@ -24,17 +21,18 @@ class DisplayConnectivityStatusInteractor extends BaseDisplayInteractor {
         mDisplayer = displayer;
     }
 
-
     @Override
-    protected Iterable<SubscriptionRequest> buildSubscriptionRequests(
+    protected SubscriptionRequest buildSubscriptionRequest(
             DisplaySubscriptionRequest.DisplaySubscriptionRequestFactory factory) {
-        return Collections.singletonList(factory.create(mConnectivityRepository.getObservable(),
+        return factory.create(
+                mConnectivityRepository.getObservable(),
                 connectivityStatus -> {
                     if (connectivityStatus.isConnected()) {
                         mDisplayer.connectivityOn();
                     } else {
                         mDisplayer.connectivityOff();
                     }
-                }));
+                }
+        );
     }
 }

--- a/domain/src/main/java/com/teamagam/gimelgimel/domain/sensors/DisplaySensorsInteractor.java
+++ b/domain/src/main/java/com/teamagam/gimelgimel/domain/sensors/DisplaySensorsInteractor.java
@@ -4,7 +4,8 @@ import com.google.auto.factory.AutoFactory;
 import com.google.auto.factory.Provided;
 import com.teamagam.gimelgimel.domain.base.executor.PostExecutionThread;
 import com.teamagam.gimelgimel.domain.base.executor.ThreadExecutor;
-import com.teamagam.gimelgimel.domain.base.interactors.BaseInteractor;
+import com.teamagam.gimelgimel.domain.base.interactors.BaseDisplayInteractor;
+import com.teamagam.gimelgimel.domain.base.interactors.DisplaySubscriptionRequest;
 import com.teamagam.gimelgimel.domain.messages.entity.contents.SensorMetadata;
 import com.teamagam.gimelgimel.domain.sensors.repository.SelectedSensorRepository;
 import com.teamagam.gimelgimel.domain.sensors.repository.SensorsRepository;
@@ -12,7 +13,7 @@ import com.teamagam.gimelgimel.domain.sensors.repository.SensorsRepository;
 import java.util.Arrays;
 
 @AutoFactory
-public class DisplaySensorsInteractor extends BaseInteractor {
+public class DisplaySensorsInteractor extends BaseDisplayInteractor {
 
     private final SensorsRepository mSensorsRepository;
     private SelectedSensorRepository mSelectedSensorRepository;
@@ -33,12 +34,12 @@ public class DisplaySensorsInteractor extends BaseInteractor {
 
 
     @Override
-    protected Iterable<SubscriptionRequest> buildSubscriptionRequests() {
-        SubscriptionRequest<SensorMetadata> displaySensors = new SubscriptionRequest<>(
-                mSensorsRepository.getSensorObservable(),
-                mDisplayer::display);
+    protected Iterable<SubscriptionRequest> buildSubscriptionRequests(
+            DisplaySubscriptionRequest.DisplaySubscriptionRequestFactory factory) {
+        DisplaySubscriptionRequest displaySensors = factory.create(
+                mSensorsRepository.getSensorObservable(), mDisplayer::display);
 
-        SubscriptionRequest<SensorMetadata> displaySelected = new SubscriptionRequest<>(
+        DisplaySubscriptionRequest displaySelected = factory.create(
                 mSelectedSensorRepository.getObservable(),
                 mDisplayer::displayAsSelected
         );


### PR DESCRIPTION
Refactoring interactors to share code when subscribing and unsubscribing from multiple (or single) observable.
Most of the sync interactors have been refactored, with the exception of few "bad" interactors that needs to change in the future.
Do interactors have not been refactored, but a new base class that supports the above refactoring have been implemented - BaseDataInteractor.
AbsInteractor, SyncInteractor and DoInteractor needs to be deleted when these changes will be adopted completely.