### PR TITLE
Disabled main activity screen orientation changes due to bug with layouts drawn after orientation changes ( map and bottom panel heights are not calculated correctly)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -36,7 +36,7 @@
         </activity>
         <activity
             android:name=".app.mainActivity.view.MainActivity"
-            android:configChanges="orientation|screenSize"
+            android:screenOrientation="portrait"
             android:label="@string/activity_main_title" />
         <activity
             android:name=".app.settings.SettingsActivity"


### PR DESCRIPTION
Disabled main activity screen orientation changes due to bug with layouts drawn after orientation changes ( map and bottom panel heights are not calculated correctly)