### PR TITLE
Each entity is drawn over the map with respect to its symbology. Fixed a map bug - tap and long-press listener were registered before their handlers could operate (since the basemap wouldn't load quick enough).

### DIFF
--- a/app/src/main/java/com/teamagam/gimelgimel/app/map/esri/EsriGGMapView.java
+++ b/app/src/main/java/com/teamagam/gimelgimel/app/map/esri/EsriGGMapView.java
@@ -134,8 +134,6 @@ public class EsriGGMapView extends MapView implements GGMapView {
     private void init() {
         setBasemap();
         setAllowRotationByPinch(true);
-        setupEntityClicksNotifications();
-        setupLongPressNotification();
     }
 
     private void setBasemap() {
@@ -194,6 +192,8 @@ public class EsriGGMapView extends MapView implements GGMapView {
         notifyMapReady();
         setOnStatusChangedListener(null);
         configureBasemap();
+        setupEntityClicksNotifications();
+        setupLongPressNotification();
     }
 
     private void setInitialExtent() {
@@ -232,9 +232,10 @@ public class EsriGGMapView extends MapView implements GGMapView {
     private void addDynamicGraphicLayer() {
         mGraphicsLayer = new GraphicsLayer();
         addLayer(mGraphicsLayer);
-        mGraphicsLayerGGAdapter = new GraphicsLayerGGAdapter(mGraphicsLayer,
-                WGS_84_GEO,
-                getSpatialReference());
+        mGraphicsLayerGGAdapter = new GraphicsLayerGGAdapter(
+                getContext(),
+                mGraphicsLayer,
+                WGS_84_GEO, getSpatialReference());
     }
 
     private void notifyMapReady() {

--- a/app/src/main/java/com/teamagam/gimelgimel/app/map/esri/EsriSymbolCreationVisitor.java
+++ b/app/src/main/java/com/teamagam/gimelgimel/app/map/esri/EsriSymbolCreationVisitor.java
@@ -1,0 +1,113 @@
+package com.teamagam.gimelgimel.app.map.esri;
+
+import android.content.Context;
+import android.graphics.Color;
+import android.graphics.drawable.Drawable;
+import android.support.v4.content.ContextCompat;
+import android.support.v4.graphics.drawable.DrawableCompat;
+
+import com.esri.core.symbol.CompositeSymbol;
+import com.esri.core.symbol.PictureMarkerSymbol;
+import com.esri.core.symbol.SimpleMarkerSymbol;
+import com.esri.core.symbol.Symbol;
+import com.esri.core.symbol.TextSymbol;
+import com.teamagam.gimelgimel.R;
+import com.teamagam.gimelgimel.domain.map.entities.interfaces.ISymbolVisitor;
+import com.teamagam.gimelgimel.domain.map.entities.symbols.AlertSymbol;
+import com.teamagam.gimelgimel.domain.map.entities.symbols.ImageSymbol;
+import com.teamagam.gimelgimel.domain.map.entities.symbols.MyLocationSymbol;
+import com.teamagam.gimelgimel.domain.map.entities.symbols.PointSymbol;
+import com.teamagam.gimelgimel.domain.map.entities.symbols.SensorSymbol;
+import com.teamagam.gimelgimel.domain.map.entities.symbols.UserSymbol;
+
+import java.util.Arrays;
+
+class EsriSymbolCreationVisitor implements ISymbolVisitor {
+
+    private static final int SYMBOL_TEXT_SIZE_DP = 15;
+    private static final int USER_CIRCLE_SIZE_DP = 10;
+    private static final int MY_LOCATION_SYMBOL_SIZE_DP = 15;
+    private static final int ACTIVE_USER_COLOR = Color.GREEN;
+    private static final int STALE_USER_COLOR = Color.RED;
+    private static final int MY_LOCATION_COLOR = Color.BLUE;
+    private static final int DEFAULT_TINT_COLOR = Color.GREEN;
+
+    private final Context mContext;
+    private Symbol mEsriSymbol;
+
+    EsriSymbolCreationVisitor(Context context) {
+        mEsriSymbol = null;
+        mContext = context;
+    }
+
+    Symbol getEsriSymbol() {
+        if (mEsriSymbol == null) {
+            return getDefaultSymbol();
+        }
+        return mEsriSymbol;
+    }
+
+    @Override
+    public void visit(PointSymbol symbol) {
+        String pointType = symbol.getType();
+        if ("building".equalsIgnoreCase(pointType)) {
+            mEsriSymbol = createPictureMarker(R.drawable.ic_business, DEFAULT_TINT_COLOR);
+        } else if ("enemy".equalsIgnoreCase(pointType)) {
+            mEsriSymbol = createPictureMarker(R.drawable.ic_flare, DEFAULT_TINT_COLOR);
+        } else {
+            mEsriSymbol = createPictureMarker(R.drawable.ic_flag, DEFAULT_TINT_COLOR);
+        }
+    }
+
+    @Override
+    public void visit(ImageSymbol symbol) {
+        mEsriSymbol = createPictureMarker(R.drawable.ic_camera, DEFAULT_TINT_COLOR);
+    }
+
+    @Override
+    public void visit(UserSymbol symbol) {
+        int symbolColor = symbol.isActive() ? ACTIVE_USER_COLOR : STALE_USER_COLOR;
+
+        Symbol usernameSymbol = new TextSymbol(
+                SYMBOL_TEXT_SIZE_DP,
+                symbol.getUserName(),
+                symbolColor,
+                TextSymbol.HorizontalAlignment.CENTER,
+                TextSymbol.VerticalAlignment.BOTTOM);
+
+        Symbol simpleMarkerSymbol = new SimpleMarkerSymbol(
+                symbolColor,
+                USER_CIRCLE_SIZE_DP,
+                SimpleMarkerSymbol.STYLE.CIRCLE);
+
+        mEsriSymbol = new CompositeSymbol(Arrays.asList(usernameSymbol, simpleMarkerSymbol));
+    }
+
+    @Override
+    public void visit(MyLocationSymbol symbol) {
+        mEsriSymbol = new SimpleMarkerSymbol(
+                MY_LOCATION_COLOR,
+                MY_LOCATION_SYMBOL_SIZE_DP,
+                SimpleMarkerSymbol.STYLE.CROSS);
+    }
+
+    @Override
+    public void visit(SensorSymbol symbol) {
+        //nothing for now, as they're not integrated
+    }
+
+    @Override
+    public void visit(AlertSymbol alertSymbol) {
+        mEsriSymbol = createPictureMarker(R.drawable.ic_alert, DEFAULT_TINT_COLOR);
+    }
+
+    private Symbol getDefaultSymbol() {
+        return new TextSymbol(10, "Pin", Color.RED);
+    }
+
+    private PictureMarkerSymbol createPictureMarker(int drawableId, int tintColor) {
+        Drawable drawable = ContextCompat.getDrawable(mContext, drawableId);
+        DrawableCompat.setTint(drawable, tintColor);
+        return new PictureMarkerSymbol(drawable);
+    }
+}

--- a/app/src/main/java/com/teamagam/gimelgimel/app/map/esri/GraphicsLayerGGAdapter.java
+++ b/app/src/main/java/com/teamagam/gimelgimel/app/map/esri/GraphicsLayerGGAdapter.java
@@ -1,26 +1,29 @@
 package com.teamagam.gimelgimel.app.map.esri;
 
-import android.graphics.Color;
+import android.content.Context;
 
 import com.esri.android.map.GraphicsLayer;
 import com.esri.core.geometry.Geometry;
 import com.esri.core.geometry.SpatialReference;
 import com.esri.core.map.Graphic;
 import com.esri.core.symbol.Symbol;
-import com.esri.core.symbol.TextSymbol;
 import com.teamagam.gimelgimel.app.common.utils.BiMap;
 import com.teamagam.gimelgimel.domain.map.entities.geometries.PointGeometry;
 import com.teamagam.gimelgimel.domain.map.entities.mapEntities.GeoEntity;
 
 public class GraphicsLayerGGAdapter {
 
+    private final Context mContext;
     private final GraphicsLayer mGraphicsLayer;
     private final SpatialReference mDataSR;
     private final SpatialReference mMapSR;
     private final BiMap<String, Integer> mEntityIdToGraphicId;
 
-    public GraphicsLayerGGAdapter(GraphicsLayer graphicsLayer, SpatialReference sourceSR,
+    public GraphicsLayerGGAdapter(Context context,
+                                  GraphicsLayer graphicsLayer,
+                                  SpatialReference sourceSR,
                                   SpatialReference mapSR) {
+        mContext = context;
         mGraphicsLayer = graphicsLayer;
         mDataSR = sourceSR;
         mMapSR = mapSR;
@@ -55,6 +58,8 @@ public class GraphicsLayerGGAdapter {
     }
 
     private Symbol createSymbol(com.teamagam.gimelgimel.domain.map.entities.symbols.Symbol symbol) {
-        return new TextSymbol(10, "Pin", Color.RED);
+        EsriSymbolCreationVisitor symbolVisitor = new EsriSymbolCreationVisitor(mContext);
+        symbol.accept(symbolVisitor);
+        return symbolVisitor.getEsriSymbol();
     }
 }

--- a/app/src/main/res/drawable/ic_alert.xml
+++ b/app/src/main/res/drawable/ic_alert.xml
@@ -1,9 +1,10 @@
-<?xml version="1.0"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="12dp"
+        android:height="12dp"
+        android:viewportHeight="24"
+        android:viewportWidth="24">
 
-<!-- drawable/alert-outline.xml -->
-
-    <vector android:viewportHeight="24" android:viewportWidth="24" android:width="24dp" android:height="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
-
-    <path android:pathData="M12,2L1,21H23M12,6L19.53,19H4.47M11,10V14H13V10M11,16V18H13V16" android:fillColor="#000"/>
+    <path android:fillColor="#000"
+          android:pathData="M12,2L1,21H23M12,6L19.53,19H4.47M11,10V14H13V10M11,16V18H13V16"/>
 
 </vector>

--- a/app/src/main/res/drawable/ic_business.xml
+++ b/app/src/main/res/drawable/ic_business.xml
@@ -1,0 +1,8 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="12dp"
+        android:height="12dp"
+        android:viewportHeight="24.0"
+        android:viewportWidth="24.0">
+    <path android:fillColor="#FFFFFF"
+          android:pathData="M12,7L12,3L2,3v18h20L22,7L12,7zM6,19L4,19v-2h2v2zM6,15L4,15v-2h2v2zM6,11L4,11L4,9h2v2zM6,7L4,7L4,5h2v2zM10,19L8,19v-2h2v2zM10,15L8,15v-2h2v2zM10,11L8,11L8,9h2v2zM10,7L8,7L8,5h2v2zM20,19h-8v-2h2v-2h-2v-2h2v-2h-2L12,9h8v10zM18,11h-2v2h2v-2zM18,15h-2v2h2v-2z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_camera.xml
+++ b/app/src/main/res/drawable/ic_camera.xml
@@ -1,7 +1,7 @@
 <!-- drawable/camera.xml -->
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="24dp"
-    android:height="24dp"
+    android:width="12dp"
+    android:height="12dp"
     android:viewportHeight="24"
     android:viewportWidth="24">
     <path

--- a/app/src/main/res/drawable/ic_flag.xml
+++ b/app/src/main/res/drawable/ic_flag.xml
@@ -1,0 +1,7 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="12dp"
+        android:height="12dp"
+        android:viewportHeight="24.0"
+        android:viewportWidth="24.0">
+    <path android:fillColor="#FFFFFF" android:pathData="M14.4,6L14,4H5v17h2v-7h5.6l0.4,2h7V6z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_flare.xml
+++ b/app/src/main/res/drawable/ic_flare.xml
@@ -1,0 +1,8 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="12dp"
+        android:height="12dp"
+        android:viewportHeight="24.0"
+        android:viewportWidth="24.0">
+    <path android:fillColor="#FFFFFF"
+          android:pathData="M7,11L1,11v2h6v-2zM9.17,7.76L7.05,5.64 5.64,7.05l2.12,2.12 1.41,-1.41zM13,1h-2v6h2L13,1zM18.36,7.05l-1.41,-1.41 -2.12,2.12 1.41,1.41 2.12,-2.12zM17,11v2h6v-2h-6zM12,9c-1.66,0 -3,1.34 -3,3s1.34,3 3,3 3,-1.34 3,-3 -1.34,-3 -3,-3zM14.83,16.24l2.12,2.12 1.41,-1.41 -2.12,-2.12 -1.41,1.41zM5.64,16.95l1.41,1.41 2.12,-2.12 -1.41,-1.41 -2.12,2.12zM11,23h2v-6h-2v6z"/>
+</vector>


### PR DESCRIPTION
Each entity is drawn over the map with respect to its symbology.
Fixed a map bug - tap and long-press listener were registered before their handlers could operate (since the basemap wouldn't load quick enough).