### PR TITLE
Vector layers updating mechanism change

### DIFF
--- a/domain/src/main/java/com/teamagam/gimelgimel/domain/layers/ProcessNewVectorLayerInteractor.java
+++ b/domain/src/main/java/com/teamagam/gimelgimel/domain/layers/ProcessNewVectorLayerInteractor.java
@@ -89,7 +89,7 @@ public class ProcessNewVectorLayerInteractor extends BaseDataInteractor {
     private boolean isOutdatedVectorLayer(VectorLayer vl) {
         String vlId = vl.getId();
         return mVectorLayerRepository.contains(vlId) &&
-                mVectorLayerRepository.get(vlId).getVersion() > vl.getVersion();
+                mVectorLayerRepository.get(vlId).getVersion() >= vl.getVersion();
     }
 
     private Observable<URI> buildProcessObservable() {


### PR DESCRIPTION
New vector layer alerts will not be processed if its version number is LTE to device's copy of that vl