### PR TITLE
Polygon/line creation interface completed

### DIFF
--- a/app/src/main/java/com/teamagam/gimelgimel/app/common/base/ViewModels/ViewDismisser.java
+++ b/app/src/main/java/com/teamagam/gimelgimel/app/common/base/ViewModels/ViewDismisser.java
@@ -1,0 +1,5 @@
+package com.teamagam.gimelgimel.app.common.base.ViewModels;
+
+public interface ViewDismisser {
+  void dismiss();
+}

--- a/app/src/main/java/com/teamagam/gimelgimel/app/map/view/BaseDrawActionFragment.java
+++ b/app/src/main/java/com/teamagam/gimelgimel/app/map/view/BaseDrawActionFragment.java
@@ -6,5 +6,9 @@ import com.teamagam.gimelgimel.app.map.viewModel.BaseMapViewModel;
 public abstract class BaseDrawActionFragment<T extends BaseMapViewModel>
     extends BaseViewModelFragment<T> {
 
+  public void finish() {
+    getActivity().finish();
+  }
+
   protected abstract String getToolbarTitle();
 }

--- a/app/src/main/java/com/teamagam/gimelgimel/app/map/view/SendGeometryActionFragment.java
+++ b/app/src/main/java/com/teamagam/gimelgimel/app/map/view/SendGeometryActionFragment.java
@@ -1,6 +1,7 @@
 package com.teamagam.gimelgimel.app.map.view;
 
 import android.os.Bundle;
+import android.support.design.widget.Snackbar;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -20,10 +21,10 @@ public class SendGeometryActionFragment extends BaseDrawActionFragment<SendGeome
 
   @BindView(R.id.send_geometry_mapview)
   GGMapView mGGMapView;
+
   private SendGeometryViewModel mViewModel;
 
   @Override
-
   public View onCreateView(LayoutInflater inflater, ViewGroup container,
       Bundle savedInstanceState) {
     View view = super.onCreateView(inflater, container, savedInstanceState);
@@ -33,6 +34,17 @@ public class SendGeometryActionFragment extends BaseDrawActionFragment<SendGeome
     setupMapClickDelegation();
 
     return bind(view).getRoot();
+  }
+
+  @Override
+  public void onDestroy() {
+    super.onDestroy();
+    mGGMapView.setOnMapGestureListener(null);
+  }
+
+  public void notifyInvalidInput() {
+    Snackbar.make(getView(), getString(R.string.send_geometry_invalid_input_message),
+        Snackbar.LENGTH_SHORT).show();
   }
 
   @Override
@@ -51,7 +63,8 @@ public class SendGeometryActionFragment extends BaseDrawActionFragment<SendGeome
   }
 
   private void initializeViewModel() {
-    mViewModel = mSendGeometryViewModelFactory.create(mGGMapView);
+    mViewModel =
+        mSendGeometryViewModelFactory.create(mGGMapView, this::notifyInvalidInput, this::finish);
     mViewModel.init();
   }
 

--- a/app/src/main/java/com/teamagam/gimelgimel/app/map/view/SendQuadrilateralActionFragment.java
+++ b/app/src/main/java/com/teamagam/gimelgimel/app/map/view/SendQuadrilateralActionFragment.java
@@ -85,10 +85,6 @@ public class SendQuadrilateralActionFragment
     }
   }
 
-  public void finish() {
-    getActivity().finish();
-  }
-
   public void hideKeyboard() {
     InputMethodManager imm =
         (InputMethodManager) getActivity().getSystemService(Context.INPUT_METHOD_SERVICE);

--- a/app/src/main/java/com/teamagam/gimelgimel/app/map/viewModel/MapDrawer.java
+++ b/app/src/main/java/com/teamagam/gimelgimel/app/map/viewModel/MapDrawer.java
@@ -1,0 +1,45 @@
+package com.teamagam.gimelgimel.app.map.viewModel;
+
+import com.teamagam.gimelgimel.app.map.view.GGMapView;
+import com.teamagam.gimelgimel.domain.map.entities.mapEntities.GeoEntity;
+import com.teamagam.gimelgimel.domain.notifications.entity.GeoEntityNotification;
+import java.util.ArrayList;
+import java.util.Collection;
+
+public class MapDrawer {
+
+  private GGMapView mGGMapView;
+  private Collection<GeoEntity> mGeoEntities;
+
+  public MapDrawer(GGMapView ggMapView) {
+    mGGMapView = ggMapView;
+    mGeoEntities = new ArrayList<>();
+  }
+
+  public void draw(GeoEntity geoEntity) {
+    mGeoEntities.add(geoEntity);
+    displayOnMap(geoEntity);
+  }
+
+  public void erase(GeoEntity geoEntity) {
+    if (mGeoEntities.contains(geoEntity)) {
+      eraseFromMap(geoEntity);
+      mGeoEntities.remove(geoEntity);
+    }
+  }
+
+  public void clear() {
+    for (GeoEntity ge : mGeoEntities) {
+      eraseFromMap(ge);
+    }
+    mGeoEntities.clear();
+  }
+
+  private void displayOnMap(GeoEntity geoEntity) {
+    mGGMapView.updateMapEntity(GeoEntityNotification.createAdd(geoEntity));
+  }
+
+  private void eraseFromMap(GeoEntity geoEntity) {
+    mGGMapView.updateMapEntity(GeoEntityNotification.createRemove(geoEntity));
+  }
+}

--- a/app/src/main/java/com/teamagam/gimelgimel/app/map/viewModel/MapEntityFactory.java
+++ b/app/src/main/java/com/teamagam/gimelgimel/app/map/viewModel/MapEntityFactory.java
@@ -1,0 +1,71 @@
+package com.teamagam.gimelgimel.app.map.viewModel;
+
+import com.teamagam.gimelgimel.domain.map.entities.geometries.PointGeometry;
+import com.teamagam.gimelgimel.domain.map.entities.geometries.Polygon;
+import com.teamagam.gimelgimel.domain.map.entities.geometries.Polyline;
+import com.teamagam.gimelgimel.domain.map.entities.mapEntities.PointEntity;
+import com.teamagam.gimelgimel.domain.map.entities.mapEntities.PolygonEntity;
+import com.teamagam.gimelgimel.domain.map.entities.mapEntities.PolylineEntity;
+import com.teamagam.gimelgimel.domain.map.entities.symbols.PointSymbol;
+import com.teamagam.gimelgimel.domain.map.entities.symbols.PolygonSymbol;
+import com.teamagam.gimelgimel.domain.map.entities.symbols.PolylineSymbol;
+import java.util.List;
+
+public class MapEntityFactory {
+
+  private static final String EMPTY_STRING = "";
+  private static int sIdCount = 0;
+  private Symbolizer mSymbolizer;
+
+  public MapEntityFactory(Symbolizer symbolizer) {
+    mSymbolizer = symbolizer;
+  }
+
+  public MapEntityFactory() {
+    this(new SimpleSymbolizer());
+  }
+
+  public PointEntity createPoint(PointGeometry point) {
+    return new PointEntity(generateId(), EMPTY_STRING, point, mSymbolizer.createFromPoint(point));
+  }
+
+  public PolylineEntity createPolyline(List<PointGeometry> points) {
+    Polyline polyline = new Polyline(points);
+    return new PolylineEntity(generateId(), EMPTY_STRING, polyline,
+        mSymbolizer.createFromPolyline(points));
+  }
+
+  public PolygonEntity createPolygon(List<PointGeometry> points) {
+    return new PolygonEntity(generateId(), EMPTY_STRING, new Polygon(points),
+        mSymbolizer.createFromPolygon(points));
+  }
+
+  private String generateId() {
+    return "generatedId_" + sIdCount++;
+  }
+
+  public interface Symbolizer {
+    PointSymbol createFromPoint(PointGeometry point);
+
+    PolylineSymbol createFromPolyline(List<PointGeometry> points);
+
+    PolygonSymbol createFromPolygon(List<PointGeometry> points);
+  }
+
+  public static class SimpleSymbolizer implements Symbolizer {
+    @Override
+    public PointSymbol createFromPoint(PointGeometry point) {
+      return new PointSymbol(false, PointSymbol.POINT_TYPE_CIRCLE);
+    }
+
+    @Override
+    public PolylineSymbol createFromPolyline(List<PointGeometry> points) {
+      return new PolylineSymbol(false);
+    }
+
+    @Override
+    public PolygonSymbol createFromPolygon(List<PointGeometry> points) {
+      return new PolygonSymbol(false);
+    }
+  }
+}

--- a/app/src/main/java/com/teamagam/gimelgimel/app/map/viewModel/MapEntityFactory.java
+++ b/app/src/main/java/com/teamagam/gimelgimel/app/map/viewModel/MapEntityFactory.java
@@ -27,18 +27,17 @@ public class MapEntityFactory {
   }
 
   public PointEntity createPoint(PointGeometry point) {
-    return new PointEntity(generateId(), EMPTY_STRING, point, mSymbolizer.createFromPoint(point));
+    return new PointEntity(generateId(), EMPTY_STRING, point, mSymbolizer.create(point));
   }
 
   public PolylineEntity createPolyline(List<PointGeometry> points) {
     Polyline polyline = new Polyline(points);
-    return new PolylineEntity(generateId(), EMPTY_STRING, polyline,
-        mSymbolizer.createFromPolyline(points));
+    return new PolylineEntity(generateId(), EMPTY_STRING, polyline, mSymbolizer.create(polyline));
   }
 
   public PolygonEntity createPolygon(List<PointGeometry> points) {
-    return new PolygonEntity(generateId(), EMPTY_STRING, new Polygon(points),
-        mSymbolizer.createFromPolygon(points));
+    Polygon polygon = new Polygon(points);
+    return new PolygonEntity(generateId(), EMPTY_STRING, polygon, mSymbolizer.create(polygon));
   }
 
   private String generateId() {
@@ -46,26 +45,26 @@ public class MapEntityFactory {
   }
 
   public interface Symbolizer {
-    PointSymbol createFromPoint(PointGeometry point);
+    PointSymbol create(PointGeometry point);
 
-    PolylineSymbol createFromPolyline(List<PointGeometry> points);
+    PolylineSymbol create(Polyline polyline);
 
-    PolygonSymbol createFromPolygon(List<PointGeometry> points);
+    PolygonSymbol create(Polygon polygon);
   }
 
   public static class SimpleSymbolizer implements Symbolizer {
     @Override
-    public PointSymbol createFromPoint(PointGeometry point) {
+    public PointSymbol create(PointGeometry point) {
       return new PointSymbol(false, PointSymbol.POINT_TYPE_CIRCLE);
     }
 
     @Override
-    public PolylineSymbol createFromPolyline(List<PointGeometry> points) {
+    public PolylineSymbol create(Polyline polyline) {
       return new PolylineSymbol(false);
     }
 
     @Override
-    public PolygonSymbol createFromPolygon(List<PointGeometry> points) {
+    public PolygonSymbol create(Polygon polygon) {
       return new PolygonSymbol(false);
     }
   }

--- a/app/src/main/java/com/teamagam/gimelgimel/app/map/viewModel/MapEntityFactory.java
+++ b/app/src/main/java/com/teamagam/gimelgimel/app/map/viewModel/MapEntityFactory.java
@@ -15,6 +15,7 @@ public class MapEntityFactory {
 
   private static final String EMPTY_STRING = "";
   private static int sIdCount = 0;
+
   private Symbolizer mSymbolizer;
 
   public MapEntityFactory(Symbolizer symbolizer) {

--- a/app/src/main/java/com/teamagam/gimelgimel/app/map/viewModel/MeasureActionViewModel.java
+++ b/app/src/main/java/com/teamagam/gimelgimel/app/map/viewModel/MeasureActionViewModel.java
@@ -7,6 +7,7 @@ import com.teamagam.gimelgimel.domain.layers.DisplayVectorLayersInteractorFactor
 import com.teamagam.gimelgimel.domain.map.DisplayMapEntitiesInteractorFactory;
 import com.teamagam.gimelgimel.domain.map.SpatialEngine;
 import com.teamagam.gimelgimel.domain.map.entities.geometries.PointGeometry;
+import com.teamagam.gimelgimel.domain.map.entities.geometries.Polyline;
 import com.teamagam.gimelgimel.domain.map.entities.symbols.PolylineSymbol;
 import com.teamagam.gimelgimel.domain.rasters.DisplayIntermediateRastersInteractorFactory;
 import java.text.DecimalFormat;
@@ -27,14 +28,12 @@ public class MeasureActionViewModel extends BaseMapViewModel {
   private double mDistanceMeters;
 
   protected MeasureActionViewModel(
-      @Provided
-          DisplayMapEntitiesInteractorFactory displayMapEntitiesInteractorFactory,
-      @Provided
-          DisplayVectorLayersInteractorFactory displayVectorLayersInteractorFactory,
+      @Provided DisplayMapEntitiesInteractorFactory displayMapEntitiesInteractorFactory,
+      @Provided DisplayVectorLayersInteractorFactory displayVectorLayersInteractorFactory,
       @Provided
           DisplayIntermediateRastersInteractorFactory displayIntermediateRastersInteractorFactory,
-      @Provided
-          SpatialEngine spatialEngine, GGMapView ggMapView) {
+      @Provided SpatialEngine spatialEngine,
+      GGMapView ggMapView) {
     super(displayMapEntitiesInteractorFactory, displayVectorLayersInteractorFactory,
         displayIntermediateRastersInteractorFactory, ggMapView);
     mSpatialEngine = spatialEngine;
@@ -116,12 +115,13 @@ public class MeasureActionViewModel extends BaseMapViewModel {
 
   private class PolylineWithDistanceTextSymbolizer extends MapEntityFactory.SimpleSymbolizer {
     @Override
-    public PolylineSymbol createFromPolyline(List<PointGeometry> points) {
+    public PolylineSymbol create(Polyline polyline) {
+      List<PointGeometry> points = polyline.getPoints();
       if (points.size() == 2) {
         String distanceString = getDistanceString(points.get(0), points.get(1));
         return new PolylineSymbol(false, distanceString);
       }
-      return super.createFromPolyline(points);
+      return super.create(polyline);
     }
 
     private String getDistanceString(PointGeometry a, PointGeometry b) {

--- a/app/src/main/java/com/teamagam/gimelgimel/app/map/viewModel/SendGeometryViewModel.java
+++ b/app/src/main/java/com/teamagam/gimelgimel/app/map/viewModel/SendGeometryViewModel.java
@@ -22,10 +22,9 @@ import static android.text.TextUtils.isEmpty;
 @AutoFactory
 public class SendGeometryViewModel extends BaseMapViewModel {
 
-  public static final String EMPTY_STRING = "";
+  private static final String EMPTY_STRING = "";
   private static AppLogger sLogger = AppLoggerFactory.create();
 
-  private final GGMapView mGGMapView;
   private final InvalidInputNotifier mInvalidInputNotifier;
   private final ViewDismisser mViewDismisser;
   private final MapDrawer mMapDrawer;
@@ -48,10 +47,9 @@ public class SendGeometryViewModel extends BaseMapViewModel {
       InvalidInputNotifier invalidInputNotifier, ViewDismisser viewDismisser) {
     super(displayMapEntitiesInteractorFactory, displayVectorLayersInteractorFactory,
         displayIntermediateRastersInteractorFactory, ggMapView);
-    mGGMapView = ggMapView;
     mInvalidInputNotifier = invalidInputNotifier;
     mViewDismisser = viewDismisser;
-    mMapDrawer = new MapDrawer(mGGMapView);
+    mMapDrawer = new MapDrawer(ggMapView);
     mMapEntityFactory = new MapEntityFactory();
     mSendGeoMessageInteractorFactory = sendGeoMessageInteractorFactory;
     mIsSwitchChecked = false;

--- a/app/src/main/java/com/teamagam/gimelgimel/app/map/viewModel/SendGeometryViewModel.java
+++ b/app/src/main/java/com/teamagam/gimelgimel/app/map/viewModel/SendGeometryViewModel.java
@@ -36,15 +36,14 @@ public class SendGeometryViewModel extends BaseMapViewModel {
   private boolean mIsSwitchChecked;
 
   protected SendGeometryViewModel(
-      @Provided
-          DisplayMapEntitiesInteractorFactory displayMapEntitiesInteractorFactory,
-      @Provided
-          DisplayVectorLayersInteractorFactory displayVectorLayersInteractorFactory,
+      @Provided DisplayMapEntitiesInteractorFactory displayMapEntitiesInteractorFactory,
+      @Provided DisplayVectorLayersInteractorFactory displayVectorLayersInteractorFactory,
       @Provided
           DisplayIntermediateRastersInteractorFactory displayIntermediateRastersInteractorFactory,
-      @Provided
-          SendGeoMessageInteractorFactory sendGeoMessageInteractorFactory, GGMapView ggMapView,
-      InvalidInputNotifier invalidInputNotifier, ViewDismisser viewDismisser) {
+      @Provided SendGeoMessageInteractorFactory sendGeoMessageInteractorFactory,
+      GGMapView ggMapView,
+      InvalidInputNotifier invalidInputNotifier,
+      ViewDismisser viewDismisser) {
     super(displayMapEntitiesInteractorFactory, displayVectorLayersInteractorFactory,
         displayIntermediateRastersInteractorFactory, ggMapView);
     mInvalidInputNotifier = invalidInputNotifier;

--- a/app/src/main/java/com/teamagam/gimelgimel/app/map/viewModel/SendGeometryViewModel.java
+++ b/app/src/main/java/com/teamagam/gimelgimel/app/map/viewModel/SendGeometryViewModel.java
@@ -2,20 +2,39 @@ package com.teamagam.gimelgimel.app.map.viewModel;
 
 import com.google.auto.factory.AutoFactory;
 import com.google.auto.factory.Provided;
+import com.teamagam.gimelgimel.app.common.base.ViewModels.ViewDismisser;
 import com.teamagam.gimelgimel.app.common.logging.AppLogger;
 import com.teamagam.gimelgimel.app.common.logging.AppLoggerFactory;
 import com.teamagam.gimelgimel.app.map.view.GGMapView;
 import com.teamagam.gimelgimel.domain.layers.DisplayVectorLayersInteractorFactory;
 import com.teamagam.gimelgimel.domain.map.DisplayMapEntitiesInteractorFactory;
+import com.teamagam.gimelgimel.domain.map.entities.geometries.Geometry;
 import com.teamagam.gimelgimel.domain.map.entities.geometries.PointGeometry;
+import com.teamagam.gimelgimel.domain.map.entities.geometries.Polygon;
+import com.teamagam.gimelgimel.domain.map.entities.geometries.Polyline;
+import com.teamagam.gimelgimel.domain.messages.SendGeoMessageInteractorFactory;
 import com.teamagam.gimelgimel.domain.rasters.DisplayIntermediateRastersInteractorFactory;
+import java.util.ArrayList;
+import java.util.List;
+
+import static android.text.TextUtils.isEmpty;
 
 @AutoFactory
 public class SendGeometryViewModel extends BaseMapViewModel {
 
+  public static final String EMPTY_STRING = "";
   private static AppLogger sLogger = AppLoggerFactory.create();
 
+  private final GGMapView mGGMapView;
+  private final InvalidInputNotifier mInvalidInputNotifier;
+  private final ViewDismisser mViewDismisser;
+  private final MapDrawer mMapDrawer;
+  private final MapEntityFactory mMapEntityFactory;
+  private final SendGeoMessageInteractorFactory mSendGeoMessageInteractorFactory;
+  private final List<PointGeometry> mSelectedPoints;
+
   private String mDescription;
+  private boolean mIsSwitchChecked;
 
   protected SendGeometryViewModel(
       @Provided
@@ -24,21 +43,44 @@ public class SendGeometryViewModel extends BaseMapViewModel {
           DisplayVectorLayersInteractorFactory displayVectorLayersInteractorFactory,
       @Provided
           DisplayIntermediateRastersInteractorFactory displayIntermediateRastersInteractorFactory,
-      GGMapView ggMapView) {
+      @Provided
+          SendGeoMessageInteractorFactory sendGeoMessageInteractorFactory, GGMapView ggMapView,
+      InvalidInputNotifier invalidInputNotifier, ViewDismisser viewDismisser) {
     super(displayMapEntitiesInteractorFactory, displayVectorLayersInteractorFactory,
         displayIntermediateRastersInteractorFactory, ggMapView);
+    mGGMapView = ggMapView;
+    mInvalidInputNotifier = invalidInputNotifier;
+    mViewDismisser = viewDismisser;
+    mMapDrawer = new MapDrawer(mGGMapView);
+    mMapEntityFactory = new MapEntityFactory();
+    mSendGeoMessageInteractorFactory = sendGeoMessageInteractorFactory;
+    mIsSwitchChecked = false;
+    mSelectedPoints = new ArrayList<>();
   }
 
   public void onSendFabClicked() {
     sLogger.userInteraction("Send geometry fab clicked");
+    if (isValidForm()) {
+      mSendGeoMessageInteractorFactory.create(mDescription, getCurrentGeometry(), EMPTY_STRING)
+          .execute();
+      mViewDismisser.dismiss();
+    } else {
+      mInvalidInputNotifier.notifyInvalid();
+    }
   }
 
   public void onUndoClicked() {
     sLogger.userInteraction("Send geometry undo clicked");
+    if (!mSelectedPoints.isEmpty()) {
+      removeLastSelectedPoint();
+      refreshDisplayedGeometry();
+    }
   }
 
   public void onSwitchChanged(boolean isChecked) {
     sLogger.userInteraction("Send geometry switch changed to " + isChecked);
+    mIsSwitchChecked = isChecked;
+    refreshDisplayedGeometry();
   }
 
   public void setDescription(String description) {
@@ -53,5 +95,82 @@ public class SendGeometryViewModel extends BaseMapViewModel {
   public void onLocationSelection(PointGeometry point) {
     sLogger.userInteraction(
         "Send geometry location selected " + point.getLatitude() + "/" + point.getLongitude());
+    mSelectedPoints.add(point);
+    refreshDisplayedGeometry();
+  }
+
+  private boolean isValidForm() {
+    return !isEmpty(mDescription) && isValidGeometry();
+  }
+
+  private boolean isValidGeometry() {
+    if (isPolylineState()) {
+      return mSelectedPoints.size() > 1;
+    } else {
+      return mSelectedPoints.size() > 2;
+    }
+  }
+
+  private Geometry getCurrentGeometry() {
+    if (isPolylineState()) {
+      return new Polyline(mSelectedPoints);
+    }
+    return new Polygon(mSelectedPoints);
+  }
+
+  private void removeLastSelectedPoint() {
+    mSelectedPoints.remove(mSelectedPoints.size() - 1);
+  }
+
+  private void refreshDisplayedGeometry() {
+    removeOldDisplayedGeometry();
+    displayCurrentGeometry();
+  }
+
+  private void removeOldDisplayedGeometry() {
+    mMapDrawer.clear();
+  }
+
+  private void displayCurrentGeometry() {
+    switch (mSelectedPoints.size()) {
+      case 0:
+        break;
+      case 1:
+        displayPoint(mSelectedPoints.get(0));
+        break;
+      case 2:
+        displayPolyline(mSelectedPoints);
+        break;
+      default:
+        displayBySwitch();
+    }
+  }
+
+  private void displayPoint(PointGeometry point) {
+    mMapDrawer.draw(mMapEntityFactory.createPoint(point));
+  }
+
+  private void displayPolyline(List<PointGeometry> points) {
+    mMapDrawer.draw(mMapEntityFactory.createPolyline(points));
+  }
+
+  private void displayBySwitch() {
+    if (isPolylineState()) {
+      displayPolyline(mSelectedPoints);
+    } else {
+      displayPolygon(mSelectedPoints);
+    }
+  }
+
+  private boolean isPolylineState() {
+    return !mIsSwitchChecked;
+  }
+
+  private void displayPolygon(List<PointGeometry> points) {
+    mMapDrawer.draw(mMapEntityFactory.createPolygon(points));
+  }
+
+  public interface InvalidInputNotifier {
+    void notifyInvalid();
   }
 }

--- a/app/src/main/java/com/teamagam/gimelgimel/app/map/viewModel/SendQuadrilateralActionViewModel.java
+++ b/app/src/main/java/com/teamagam/gimelgimel/app/map/viewModel/SendQuadrilateralActionViewModel.java
@@ -24,8 +24,8 @@ public class SendQuadrilateralActionViewModel
 
   private static final String QUADRILATERAL_LONG_PREF = "quadrilateralLong";
   private static final String QUADRILATERAL_LAT_PREF = "quadrilateralLat";
-  private static final String EMPTY_STRING = "";
   private static final String QUADRILATERAL_DESC_PREF = "quadrilateralDesc";
+  private static final String EMPTY_STRING = "";
 
   private final SendGeoMessageInteractorFactory mSendGeoMessageInteractorFactory;
   private final GGMapView mGGMapView;

--- a/app/src/main/java/com/teamagam/gimelgimel/app/message/view/SendGeographicMessageDialog.java
+++ b/app/src/main/java/com/teamagam/gimelgimel/app/message/view/SendGeographicMessageDialog.java
@@ -10,6 +10,7 @@ import android.view.LayoutInflater;
 import android.view.View;
 import com.teamagam.gimelgimel.BR;
 import com.teamagam.gimelgimel.R;
+import com.teamagam.gimelgimel.app.common.base.ViewModels.ViewDismisser;
 import com.teamagam.gimelgimel.app.common.base.view.fragments.dialogs.BaseBindingDialogFragment;
 import com.teamagam.gimelgimel.app.mainActivity.view.MainActivity;
 import com.teamagam.gimelgimel.app.map.model.geometries.PointGeometryApp;
@@ -24,7 +25,7 @@ import javax.inject.Inject;
  * associated geographical location.
  */
 public class SendGeographicMessageDialog extends BaseBindingDialogFragment
-    implements SendGeoMessageViewModel.IViewDismisser {
+    implements ViewDismisser {
 
   private static final String ARG_POINT_GEOMETRY =
       SendGeographicMessageDialog.class.getSimpleName() + "_PointGeometry";

--- a/app/src/main/java/com/teamagam/gimelgimel/app/message/viewModel/SendGeoMessageViewModel.java
+++ b/app/src/main/java/com/teamagam/gimelgimel/app/message/viewModel/SendGeoMessageViewModel.java
@@ -2,6 +2,7 @@ package com.teamagam.gimelgimel.app.message.viewModel;
 
 import android.content.Context;
 import com.teamagam.gimelgimel.R;
+import com.teamagam.gimelgimel.app.common.base.ViewModels.ViewDismisser;
 import com.teamagam.gimelgimel.app.map.model.geometries.PointGeometryApp;
 import com.teamagam.gimelgimel.domain.map.SpatialEngine;
 import com.teamagam.gimelgimel.domain.map.entities.geometries.PointGeometry;
@@ -31,7 +32,7 @@ public class SendGeoMessageViewModel extends SendMessageViewModel {
     super();
   }
 
-  public void init(IViewDismisser view, PointGeometryApp point) {
+  public void init(ViewDismisser view, PointGeometryApp point) {
     mTypes = mContext.getResources().getStringArray(R.array.geo_location_types);
     mPoint = point;
     mView = view;

--- a/app/src/main/java/com/teamagam/gimelgimel/app/message/viewModel/SendMessageViewModel.java
+++ b/app/src/main/java/com/teamagam/gimelgimel/app/message/viewModel/SendMessageViewModel.java
@@ -3,6 +3,7 @@ package com.teamagam.gimelgimel.app.message.viewModel;
 import android.databinding.Bindable;
 import com.teamagam.gimelgimel.BR;
 import com.teamagam.gimelgimel.app.common.base.ViewModels.BaseViewModel;
+import com.teamagam.gimelgimel.app.common.base.ViewModels.ViewDismisser;
 import com.teamagam.gimelgimel.app.common.logging.AppLogger;
 import com.teamagam.gimelgimel.app.common.logging.AppLoggerFactory;
 import com.teamagam.gimelgimel.domain.messages.SendTextMessageInteractor;
@@ -11,7 +12,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.inject.Inject;
 
-public class SendMessageViewModel extends BaseViewModel<SendMessageViewModel.IViewDismisser> {
+public class SendMessageViewModel extends BaseViewModel<ViewDismisser> {
   protected AppLogger sLogger = AppLoggerFactory.create(this.getClass());
   protected String mText;
   @Inject
@@ -48,9 +49,5 @@ public class SendMessageViewModel extends BaseViewModel<SendMessageViewModel.IVi
     Pattern p = Pattern.compile("\\S");
     Matcher m = p.matcher(mText);
     return m.find();
-  }
-
-  public interface IViewDismisser {
-    void dismiss();
   }
 }

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -37,7 +37,6 @@
   <string name="send_image_button_description">שלח תמונה</string>
   <string name="send_quadrilateral_action_description">הזן נקודות מרובע</string>
   <string name="show">הצג</string>
-  <string name="send_quadrilateral_invalid_input_message">קלט בלתי תקין</string>
   <string name="send_quadrilateral_lnglatpicker1_label">נקודה 1</string>
   <string name="send_quadrilateral_lnglatpicker2_label">נקודה 2</string>
   <string name="send_quadrilateral_lnglatpicker3_label">נקודה 3</string>
@@ -66,4 +65,5 @@
   <string name="horizontal_long_lat_picker_y_hint">קואורדינטת Y</string>
   <string name="menu_use_utm_title">השתמש במערכת UTM</string>
   <string name="send_geometry_toolbar_title">שלח גיאומטריה</string>
+  <string name="invalid_input_message">קלט לא תקין</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -75,6 +75,10 @@
   <string name="text_message_hint">Type a message</string>
   <string name="send_image_button_description">Send Image</string>
 
+  <!--Common messages -->
+  <string name="invalid_input_message">Invalid input</string>
+
+
   <!--Draw Actions-->
   <string name="menu_action_send_quadrilateral_title">Send Quadrilateral</string>
   <string name="menu_action_draw_geometry_title">Draw Geometry</string>
@@ -84,7 +88,7 @@
   <!--Send Quadrilateral-->
   <string name="send_quadrilateral_action_description">Fill quadrilateral points</string>
   <string name="send_quadrilateral_action_show_button" translatable="false">@string/show</string>
-  <string name="send_quadrilateral_invalid_input_message">Invalid input</string>
+  <string name="send_quadrilateral_invalid_input_message" translatable="false">@string/invalid_input_message</string>
   <string name="send_quadrilateral_lnglatpicker1_label">Point 1</string>
   <string name="send_quadrilateral_lnglatpicker2_label">Point 2</string>
   <string name="send_quadrilateral_lnglatpicker3_label">Point 3</string>
@@ -100,6 +104,7 @@
 
   <!--Send Geometry -->
   <string name="send_geometry_toolbar_title">Send Geometry</string>
+  <string name="send_geometry_invalid_input_message" translatable="false">@string/send_quadrilateral_invalid_input_message</string>
 
   <!--Long Lat Picker-->
   <string name="horizontal_long_lat_picker_long_hint">Longitude</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -104,7 +104,7 @@
 
   <!--Send Geometry -->
   <string name="send_geometry_toolbar_title">Send Geometry</string>
-  <string name="send_geometry_invalid_input_message" translatable="false">@string/send_quadrilateral_invalid_input_message</string>
+  <string name="send_geometry_invalid_input_message" translatable="false">@string/invalid_input_message</string>
 
   <!--Long Lat Picker-->
   <string name="horizontal_long_lat_picker_long_hint">Longitude</string>


### PR DESCRIPTION
Implemented send geometry (polylines and polygons) view-model logic.
You can now create and send polylines and polygons from the tablet.

Refactoring -
Introduced MapDrawer and MapEntityFactory to allow easy creation and manipulation of entities over the map.
These are used in the new code and in MeasureViewModel and SendQuadrilateralViewModel.