### PR TITLE
Clear cache dev. option

### DIFF
--- a/app/src/main/java/com/teamagam/gimelgimel/app/GGApplication.java
+++ b/app/src/main/java/com/teamagam/gimelgimel/app/GGApplication.java
@@ -1,6 +1,7 @@
 package com.teamagam.gimelgimel.app;
 
 import android.app.Application;
+import android.content.Intent;
 import com.teamagam.gimelgimel.R;
 import com.teamagam.gimelgimel.app.common.logging.AppLoggerFactory;
 import com.teamagam.gimelgimel.app.injectors.components.ApplicationComponent;
@@ -23,12 +24,6 @@ public class GGApplication extends Application {
     init();
   }
 
-  private void initializeInjector() {
-    mApplicationComponent =
-        DaggerApplicationComponent.builder().applicationModule(new ApplicationModule(this)).build();
-    mApplicationComponent.inject(this);
-  }
-
   public ApplicationComponent getApplicationComponent() {
     return mApplicationComponent;
   }
@@ -37,6 +32,12 @@ public class GGApplication extends Application {
     initializeInjector();
     initializeLoggers();
     initializeMessagePolling();
+  }
+
+  private void initializeInjector() {
+    mApplicationComponent =
+        DaggerApplicationComponent.builder().applicationModule(new ApplicationModule(this)).build();
+    mApplicationComponent.inject(this);
   }
 
   private void initializeMessagePolling() {

--- a/app/src/main/java/com/teamagam/gimelgimel/app/GGApplication.java
+++ b/app/src/main/java/com/teamagam/gimelgimel/app/GGApplication.java
@@ -1,7 +1,6 @@
 package com.teamagam.gimelgimel.app;
 
 import android.app.Application;
-import android.content.Intent;
 import com.teamagam.gimelgimel.R;
 import com.teamagam.gimelgimel.app.common.logging.AppLoggerFactory;
 import com.teamagam.gimelgimel.app.injectors.components.ApplicationComponent;

--- a/app/src/main/java/com/teamagam/gimelgimel/app/injectors/components/ApplicationComponent.java
+++ b/app/src/main/java/com/teamagam/gimelgimel/app/injectors/components/ApplicationComponent.java
@@ -13,6 +13,7 @@ import com.teamagam.gimelgimel.app.map.esri.EsriGGMapView;
 import com.teamagam.gimelgimel.app.map.view.MeasureActionFragment;
 import com.teamagam.gimelgimel.app.map.view.SendQuadrilateralActionFragment;
 import com.teamagam.gimelgimel.app.message.view.ImageFullscreenActivity;
+import com.teamagam.gimelgimel.data.common.FilesDownloader;
 import com.teamagam.gimelgimel.data.location.LocationFetcher;
 import com.teamagam.gimelgimel.domain.alerts.repository.AlertsRepository;
 import com.teamagam.gimelgimel.domain.alerts.repository.InformedAlertsRepository;
@@ -159,4 +160,6 @@ public interface ApplicationComponent {
   NewMessageIndicationRepository newMessageIndicationRepository();
 
   SpatialEngine spatialEngine();
+
+  FilesDownloader filesDownloader();
 }

--- a/app/src/main/java/com/teamagam/gimelgimel/app/mainActivity/view/MainActivity.java
+++ b/app/src/main/java/com/teamagam/gimelgimel/app/mainActivity/view/MainActivity.java
@@ -7,7 +7,6 @@ import android.support.v4.app.FragmentManager;
 import android.support.v4.view.GravityCompat;
 import android.support.v4.widget.DrawerLayout;
 import android.view.Menu;
-import android.view.MenuInflater;
 import android.view.MenuItem;
 import butterknife.BindView;
 import com.teamagam.gimelgimel.R;
@@ -43,12 +42,17 @@ public class MainActivity extends BaseActivity<GGApplication> {
   @Inject
   Navigator mNavigator;
 
+  @Inject
+  MainOptionsMenuFactory mMainOptionsMenuFactory;
+
   //app fragments
   private ViewerFragment mViewerFragment;
   //injectors
   private MainActivityComponent mMainActivityComponent;
 
   private MainActivityPanel mBottomPanel;
+
+  private MainOptionsMenu mMainOptionsMenu;
 
   @Override
   public void onBackPressed() {
@@ -65,26 +69,17 @@ public class MainActivity extends BaseActivity<GGApplication> {
 
   @Override
   public boolean onCreateOptionsMenu(Menu menu) {
-    MenuInflater inflater = getMenuInflater();
-    inflater.inflate(R.menu.main, menu);
-    MenuItem useUtmItem = menu.findItem(R.id.action_use_utm);
-    useUtmItem.setChecked(mPreferencesUtils.shouldUseUtm());
-    return super.onCreateOptionsMenu(menu);
+    mMainOptionsMenu.onCreate(menu);
+    return true;
   }
 
   @Override
   public boolean onOptionsItemSelected(MenuItem item) {
-    switch (item.getItemId()) {
-      case android.R.id.home:
-        mDrawerLayout.openDrawer(GravityCompat.START);
-        return true;
-      case R.id.action_use_utm:
-        sLogger.userInteraction("Change coordinate system menu option item clicked");
-        mPreferencesUtils.toggleCoordinateSystemPrefs();
-        item.setChecked(mPreferencesUtils.shouldUseUtm());
-      default:
-        return super.onOptionsItemSelected(item);
+    if (item.getItemId() == android.R.id.home) {
+      mDrawerLayout.openDrawer(GravityCompat.START);
+      return true;
     }
+    return mMainOptionsMenu.onItemSelected(item) || super.onOptionsItemSelected(item);
   }
 
   public ViewerFragment getViewerFragment() {
@@ -135,6 +130,7 @@ public class MainActivity extends BaseActivity<GGApplication> {
     initBottomPanel();
     initMainNotifications();
     initBubbleAlerts();
+    initOptionsMenu();
   }
 
   private void initDrawer() {
@@ -174,6 +170,10 @@ public class MainActivity extends BaseActivity<GGApplication> {
   private void initBubbleAlerts() {
     AlertsSubcomponent alertsSubcomponent = new AlertsSubcomponent(this);
     attachSubcomponent(alertsSubcomponent);
+  }
+
+  private void initOptionsMenu() {
+    mMainOptionsMenu = mMainOptionsMenuFactory.create(getMenuInflater(), this);
   }
 
   private void handleGpsEnabledState() {

--- a/app/src/main/java/com/teamagam/gimelgimel/app/mainActivity/view/MainOptionsMenu.java
+++ b/app/src/main/java/com/teamagam/gimelgimel/app/mainActivity/view/MainOptionsMenu.java
@@ -1,0 +1,76 @@
+package com.teamagam.gimelgimel.app.mainActivity.view;
+
+import android.content.Context;
+import android.view.Menu;
+import android.view.MenuInflater;
+import android.view.MenuItem;
+import android.widget.Toast;
+import com.google.auto.factory.AutoFactory;
+import com.google.auto.factory.Provided;
+import com.teamagam.gimelgimel.BuildConfig;
+import com.teamagam.gimelgimel.R;
+import com.teamagam.gimelgimel.app.common.logging.AppLogger;
+import com.teamagam.gimelgimel.app.common.logging.AppLoggerFactory;
+import com.teamagam.gimelgimel.data.layers.LayersLocalCacheData;
+import com.teamagam.gimelgimel.domain.utils.PreferencesUtils;
+
+@AutoFactory
+public class MainOptionsMenu {
+  private static final int CLEAR_CACHE_MENU_ITEM_ID = 739;
+
+  private final static AppLogger sLogger = AppLoggerFactory.create();
+
+  private final MenuInflater mMenuInflater;
+  private final PreferencesUtils mPreferencesUtils;
+  private final LayersLocalCacheData mLayersLocalCacheData;
+  private final Context mContext;
+
+  public MainOptionsMenu(@Provided PreferencesUtils preferencesUtils,
+      @Provided LayersLocalCacheData layersLocalCacheData,
+      MenuInflater menuInflater,
+      Context context) {
+    mMenuInflater = menuInflater;
+    mPreferencesUtils = preferencesUtils;
+    mLayersLocalCacheData = layersLocalCacheData;
+    mContext = context;
+  }
+
+  public void onCreate(Menu menu) {
+    mMenuInflater.inflate(R.menu.main, menu);
+    MenuItem useUtmItem = menu.findItem(R.id.menu_item_use_utm);
+    useUtmItem.setChecked(mPreferencesUtils.shouldUseUtm());
+    if (BuildConfig.DEBUG) {
+      menu.add(Menu.NONE, CLEAR_CACHE_MENU_ITEM_ID, Menu.NONE, R.string.menu_clear_vl_cache_title);
+    }
+  }
+
+  public boolean onItemSelected(MenuItem menuItem) {
+    switch (menuItem.getItemId()) {
+      case R.id.menu_item_use_utm:
+        onUseUTMClicked(menuItem);
+        return true;
+      case CLEAR_CACHE_MENU_ITEM_ID:
+        onClearCacheClicked();
+        return true;
+      default:
+        return false;
+    }
+  }
+
+  private void onUseUTMClicked(MenuItem menuItem) {
+    sLogger.userInteraction("Change coordinate system menu option item clicked");
+
+    mPreferencesUtils.toggleCoordinateSystemPrefs();
+    menuItem.setChecked(mPreferencesUtils.shouldUseUtm());
+  }
+
+  private void onClearCacheClicked() {
+    sLogger.userInteraction("Clear VL cache clicked");
+    boolean success = mLayersLocalCacheData.clearCache();
+    Toast.makeText(mContext, getClearVLMessage(success), Toast.LENGTH_LONG).show();
+  }
+
+  private int getClearVLMessage(boolean success) {
+    return success ? R.string.clear_cache_successful_message : R.string.clear_cache_failure_message;
+  }
+}

--- a/app/src/main/res/menu/main.xml
+++ b/app/src/main/res/menu/main.xml
@@ -4,7 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     tools:context=".MainActivity">
   <item
-      android:id="@+id/action_use_utm"
+      android:id="@+id/menu_item_use_utm"
       android:checkable="true"
       android:orderInCategory="1"
       android:title="@string/menu_use_utm_title"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -122,6 +122,9 @@
   <string name="dialog_go_to_long_lat_label">Destination</string>
   <string name="unknown_location">Unknown location</string>
   <string name="menu_use_utm_title">Use UTM</string>
+  <string name="menu_clear_vl_cache_title" translatable="false">Clear VL Cache</string>
+  <string name="clear_cache_successful_message" translatable="false">All layers successfully deleted</string>
+  <string name="clear_cache_failure_message" translatable="false">Couldn\'t delete all layers</string>
 
   <!--Name Generator-->
   <string-array name="name_generator_animals" translatable="false">

--- a/data/src/main/java/com/teamagam/gimelgimel/data/layers/LayersLocalCacheData.java
+++ b/data/src/main/java/com/teamagam/gimelgimel/data/layers/LayersLocalCacheData.java
@@ -27,7 +27,8 @@ public class LayersLocalCacheData implements LayersLocalCache {
 
   @Inject
   public LayersLocalCacheData(ExternalDirProvider externalDirProvider,
-      FilesDownloader filesDownloader, LayerFilenameSerializer layerFilenameSerializer) {
+      FilesDownloader filesDownloader,
+      LayerFilenameSerializer layerFilenameSerializer) {
     mExternalVectorLayersDir = new File(externalDirProvider.getExternalFilesDir()
         + File.separator
         + Constants.VECTOR_LAYERS_CACHE_DIR_NAME);
@@ -57,6 +58,14 @@ public class LayersLocalCacheData implements LayersLocalCache {
       return Collections.emptyList();
     }
     return extractVectorLayersFromFiles(vectorLayerFiles);
+  }
+
+  public boolean clearCache() {
+    boolean success = true;
+    for (File file : mExternalVectorLayersDir.listFiles()) {
+      success &= file.delete();
+    }
+    return success;
   }
 
   private URI downloadToCache(VectorLayer vectorLayer, URL url) {


### PR DESCRIPTION
Extracted MainActivity menu handling to its dedicated class - MainOptionsMenu.
Added support for a new action on debug mode - Clear VL Cache
This action deletes all the vector layers form the disk and notifies through a toast to the user (developer) if the operation succeeded / failed.