### PR TITLE
Exposing map drag events from GGMapView (via observable)

### DIFF
--- a/app/src/main/java/com/teamagam/gimelgimel/app/map/GGMapView.java
+++ b/app/src/main/java/com/teamagam/gimelgimel/app/map/GGMapView.java
@@ -5,6 +5,7 @@ import com.teamagam.gimelgimel.domain.map.entities.geometries.Geometry;
 import com.teamagam.gimelgimel.domain.map.entities.geometries.PointGeometry;
 import com.teamagam.gimelgimel.domain.notifications.entity.GeoEntityNotification;
 import com.teamagam.gimelgimel.domain.rasters.entity.IntermediateRaster;
+import io.reactivex.Observable;
 
 public interface GGMapView {
 
@@ -33,6 +34,8 @@ public interface GGMapView {
   void removeIntermediateRaster();
 
   PointGeometry getMapCenter();
+
+  Observable<MapDragEvent> getMapDragEventObservable();
 
   void setAllowPanning(boolean allow);
 

--- a/app/src/main/java/com/teamagam/gimelgimel/app/map/MapDragEvent.java
+++ b/app/src/main/java/com/teamagam/gimelgimel/app/map/MapDragEvent.java
@@ -1,0 +1,22 @@
+package com.teamagam.gimelgimel.app.map;
+
+import com.teamagam.gimelgimel.domain.map.entities.geometries.PointGeometry;
+
+public class MapDragEvent {
+
+  private final PointGeometry mFrom;
+  private final PointGeometry mTo;
+
+  public MapDragEvent(PointGeometry from, PointGeometry to) {
+    mFrom = from;
+    mTo = to;
+  }
+
+  public PointGeometry getFrom() {
+    return mFrom;
+  }
+
+  public PointGeometry getTo() {
+    return mTo;
+  }
+}

--- a/app/src/main/java/com/teamagam/gimelgimel/app/map/actions/freedraw/FreeDrawActionFragment.java
+++ b/app/src/main/java/com/teamagam/gimelgimel/app/map/actions/freedraw/FreeDrawActionFragment.java
@@ -12,6 +12,7 @@ import com.teamagam.gimelgimel.R;
 import com.teamagam.gimelgimel.app.map.GGMapView;
 import com.teamagam.gimelgimel.app.map.actions.BaseDrawActionFragment;
 import com.teamagam.gimelgimel.databinding.FragmentFreeDrawBinding;
+import com.teamagam.gimelgimel.domain.base.subscribers.ErrorLoggingObserver;
 import javax.inject.Inject;
 
 public class FreeDrawActionFragment extends BaseDrawActionFragment<FreedrawViewModel> {
@@ -40,6 +41,17 @@ public class FreeDrawActionFragment extends BaseDrawActionFragment<FreedrawViewM
     binding.setViewModel(mFreedrawViewModel);
 
     mGGMapView.setAllowPanning(false);
+
+    mGGMapView.getMapDragEventObservable()
+        .doOnNext(mde -> sLogger.v("drag-event: "
+            + mde.getFrom().getLongitude()
+            + ","
+            + mde.getFrom().getLatitude()
+            + " - "
+            + mde.getTo().getLongitude()
+            + ","
+            + mde.getTo().getLatitude()))
+        .subscribe(new ErrorLoggingObserver<>());
     displayTwoFingersToast();
 
     return view;

--- a/app/src/main/java/com/teamagam/gimelgimel/app/map/esri/EsriGGMapView.java
+++ b/app/src/main/java/com/teamagam/gimelgimel/app/map/esri/EsriGGMapView.java
@@ -437,7 +437,7 @@ public class EsriGGMapView extends MapView implements GGMapView {
         EsriGGMapView.this::screenToGround);
   }
 
-  private MapDragEventsEmitterTouchListenerDecorator getUnpannableMapTouchListener() {
+  private OnTouchListener getUnpannableMapTouchListener() {
     return new MapDragEventsEmitterTouchListenerDecorator(
         new IgnoreDragMapOnTouchListener(EsriGGMapView.this), this, mMapDragEventSubject,
         EsriGGMapView.this::screenToGround);

--- a/app/src/main/java/com/teamagam/gimelgimel/app/map/esri/EsriGGMapView.java
+++ b/app/src/main/java/com/teamagam/gimelgimel/app/map/esri/EsriGGMapView.java
@@ -5,7 +5,6 @@ import android.content.SharedPreferences;
 import android.location.LocationListener;
 import android.preference.PreferenceManager;
 import android.util.AttributeSet;
-import android.view.MotionEvent;
 import android.widget.RelativeLayout;
 import com.esri.android.map.GraphicsLayer;
 import com.esri.android.map.Layer;
@@ -28,6 +27,7 @@ import com.teamagam.gimelgimel.app.common.logging.AppLogger;
 import com.teamagam.gimelgimel.app.common.logging.AppLoggerFactory;
 import com.teamagam.gimelgimel.app.common.utils.Constants;
 import com.teamagam.gimelgimel.app.map.GGMapView;
+import com.teamagam.gimelgimel.app.map.MapDragEvent;
 import com.teamagam.gimelgimel.app.map.MapEntityClickedListener;
 import com.teamagam.gimelgimel.app.map.OnMapGestureListener;
 import com.teamagam.gimelgimel.app.map.esri.graphic.EsriSymbolCreator;
@@ -46,6 +46,8 @@ import com.teamagam.gimelgimel.domain.rasters.entity.IntermediateRaster;
 import io.reactivex.Observable;
 import io.reactivex.functions.Action;
 import io.reactivex.schedulers.Schedulers;
+import io.reactivex.subjects.PublishSubject;
+import io.reactivex.subjects.Subject;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Map;
@@ -80,6 +82,10 @@ public class EsriGGMapView extends MapView implements GGMapView {
   private LocationDisplayer mLocationDisplayer;
   private Compass mCompass;
   private ScaleBar mScaleBar;
+
+  private Subject<MapDragEvent> mMapDragEventSubject;
+  private OnTouchListener mPannableMapTouchListener;
+  private OnTouchListener mUnpannableMapTouchListener;
 
   public EsriGGMapView(Context context) {
     super(context);
@@ -134,6 +140,11 @@ public class EsriGGMapView extends MapView implements GGMapView {
   public PointGeometry getMapCenter() {
     Point point = projectToWgs84(getCenter());
     return new PointGeometry(point.getY(), point.getX());
+  }
+
+  @Override
+  public Observable<MapDragEvent> getMapDragEventObservable() {
+    return mMapDragEventSubject;
   }
 
   @Override
@@ -209,6 +220,9 @@ public class EsriGGMapView extends MapView implements GGMapView {
     mLocationDisplayer = getLocationDisplayer(context);
     mIntermediateRasterDisplayer =
         new IntermediateRasterDisplayer(this, INTERMEDIATE_LAYER_POSITION);
+    mMapDragEventSubject = PublishSubject.create();
+    mPannableMapTouchListener = getPannableMapTouchListener();
+    mUnpannableMapTouchListener = getUnpannableMapTouchListener();
   }
 
   private void setBasemap() {
@@ -417,6 +431,18 @@ public class EsriGGMapView extends MapView implements GGMapView {
     return new LocationDisplayer(getLocationDisplayManager(), locationListener);
   }
 
+  private OnTouchListener getPannableMapTouchListener() {
+    return new MapDragEventsEmitterTouchListenerDecorator(
+        new MapOnTouchListener(getContext(), this), this, mMapDragEventSubject,
+        EsriGGMapView.this::screenToGround);
+  }
+
+  private MapDragEventsEmitterTouchListenerDecorator getUnpannableMapTouchListener() {
+    return new MapDragEventsEmitterTouchListenerDecorator(
+        new IgnoreDragMapOnTouchListener(EsriGGMapView.this), this, mMapDragEventSubject,
+        EsriGGMapView.this::screenToGround);
+  }
+
   private void stopPlugin(SelfUpdatingViewPlugin plugin) {
     if (plugin != null) {
       plugin.stop();
@@ -435,11 +461,11 @@ public class EsriGGMapView extends MapView implements GGMapView {
   }
 
   private void enablePanning() {
-    setOnTouchListener(new MapOnTouchListener(getContext(), this));
+    setOnTouchListener(mPannableMapTouchListener);
   }
 
   private void disablePanning() {
-    setOnTouchListener(new IgnoreDragMapOnTouchListener());
+    setOnTouchListener(mUnpannableMapTouchListener);
   }
 
   private Geometry transformToEsri(com.teamagam.gimelgimel.domain.map.entities.geometries.Geometry geometry) {
@@ -626,22 +652,6 @@ public class EsriGGMapView extends MapView implements GGMapView {
       if (mOnMapGestureListener != null) {
         mOnMapGestureListener.onLongPress(pointGeometry);
       }
-    }
-  }
-
-  private class IgnoreDragMapOnTouchListener extends MapOnTouchListener {
-    public IgnoreDragMapOnTouchListener() {
-      super(EsriGGMapView.this.getContext(), EsriGGMapView.this);
-    }
-
-    @Override
-    public boolean onFling(MotionEvent from, MotionEvent to, float velocityX, float velocityY) {
-      return true;
-    }
-
-    @Override
-    public boolean onDragPointerMove(MotionEvent from, MotionEvent to) {
-      return true;
     }
   }
 }

--- a/app/src/main/java/com/teamagam/gimelgimel/app/map/esri/IgnoreDragMapOnTouchListener.java
+++ b/app/src/main/java/com/teamagam/gimelgimel/app/map/esri/IgnoreDragMapOnTouchListener.java
@@ -1,0 +1,20 @@
+package com.teamagam.gimelgimel.app.map.esri;
+
+import android.view.MotionEvent;
+import com.esri.android.map.MapOnTouchListener;
+
+class IgnoreDragMapOnTouchListener extends MapOnTouchListener {
+  IgnoreDragMapOnTouchListener(EsriGGMapView mapView) {
+    super(mapView.getContext(), mapView);
+  }
+
+  @Override
+  public boolean onFling(MotionEvent from, MotionEvent to, float velocityX, float velocityY) {
+    return true;
+  }
+
+  @Override
+  public boolean onDragPointerMove(MotionEvent from, MotionEvent to) {
+    return true;
+  }
+}

--- a/app/src/main/java/com/teamagam/gimelgimel/app/map/esri/MapDragEventsEmitterTouchListenerDecorator.java
+++ b/app/src/main/java/com/teamagam/gimelgimel/app/map/esri/MapDragEventsEmitterTouchListenerDecorator.java
@@ -1,0 +1,112 @@
+package com.teamagam.gimelgimel.app.map.esri;
+
+import android.view.MotionEvent;
+import android.view.View;
+import com.esri.android.map.MapOnTouchListener;
+import com.esri.android.map.MapView;
+import com.teamagam.gimelgimel.app.map.MapDragEvent;
+import com.teamagam.gimelgimel.domain.map.entities.geometries.PointGeometry;
+import io.reactivex.functions.BiFunction;
+import io.reactivex.subjects.Subject;
+
+class MapDragEventsEmitterTouchListenerDecorator implements View.OnTouchListener {
+
+  private MapOnTouchListener mDecorated;
+  private MapDragEventsEmitter mMapDragEventsEmitter;
+
+  public MapDragEventsEmitterTouchListenerDecorator(MapOnTouchListener decorated,
+      EsriGGMapView esriGGMapView,
+      Subject<MapDragEvent> subject,
+      BiFunction<Float, Float, PointGeometry> screenToGround) {
+    mDecorated = decorated;
+    mMapDragEventsEmitter = new MapDragEventsEmitter(esriGGMapView, subject, screenToGround);
+  }
+
+  @Override
+  public boolean onTouch(View v, MotionEvent event) {
+    mMapDragEventsEmitter.onTouch(v, event);
+    return mDecorated.onTouch(v, event);
+  }
+
+  private class MapDragEventsEmitter extends MapOnTouchListener {
+
+    private final Subject<MapDragEvent> mMapDragEventSubject;
+    private final BiFunction<Float, Float, PointGeometry> mScreenToGrounder;
+
+    public MapDragEventsEmitter(MapView view,
+        Subject<MapDragEvent> mapDragEventSubject,
+        BiFunction<Float, Float, PointGeometry> screenToGrounder) {
+      super(view.getContext(), view);
+      mMapDragEventSubject = mapDragEventSubject;
+      mScreenToGrounder = screenToGrounder;
+    }
+
+    @Override
+    public boolean onDragPointerUp(MotionEvent from, MotionEvent to) {
+      return true;
+    }
+
+    @Override
+    public boolean onPinchPointersDown(MotionEvent event) {
+      return true;
+    }
+
+    @Override
+    public boolean onPinchPointersMove(MotionEvent event) {
+      return true;
+    }
+
+    @Override
+    public boolean onPinchPointersUp(MotionEvent event) {
+      return true;
+    }
+
+    @Override
+    public boolean onDoubleTap(MotionEvent point) {
+      return true;
+    }
+
+    @Override
+    public boolean onLongPressUp(MotionEvent point) {
+      return true;
+    }
+
+    @Override
+    public boolean onSingleTap(MotionEvent point) {
+      return true;
+    }
+
+    @Override
+    public boolean onFling(MotionEvent from, MotionEvent to, float velocityX, float velocityY) {
+      return true;
+    }
+
+    @Override
+    public boolean onDoubleTapDrag(MotionEvent from, MotionEvent to) {
+      return true;
+    }
+
+    @Override
+    public boolean onDoubleTapDragUp(MotionEvent up) {
+      return true;
+    }
+
+    @Override
+    public boolean onDragPointerMove(MotionEvent from, MotionEvent to) {
+      mMapDragEventSubject.onNext(createDragEvent(from, to));
+      return true;
+    }
+
+    private MapDragEvent createDragEvent(MotionEvent from, MotionEvent to) {
+      return new MapDragEvent(motionEventToGround(from), motionEventToGround(to));
+    }
+
+    private PointGeometry motionEventToGround(MotionEvent motionEvent) {
+      try {
+        return mScreenToGrounder.apply(motionEvent.getX(), motionEvent.getY());
+      } catch (Exception e) {
+        throw new RuntimeException("Couldn't calculate screen to ground", e);
+      }
+    }
+  }
+}

--- a/app/src/main/java/com/teamagam/gimelgimel/app/map/esri/MapDragEventsEmitterTouchListenerDecorator.java
+++ b/app/src/main/java/com/teamagam/gimelgimel/app/map/esri/MapDragEventsEmitterTouchListenerDecorator.java
@@ -11,10 +11,10 @@ import io.reactivex.subjects.Subject;
 
 class MapDragEventsEmitterTouchListenerDecorator implements View.OnTouchListener {
 
-  private MapOnTouchListener mDecorated;
+  private View.OnTouchListener mDecorated;
   private MapDragEventsEmitter mMapDragEventsEmitter;
 
-  public MapDragEventsEmitterTouchListenerDecorator(MapOnTouchListener decorated,
+  public MapDragEventsEmitterTouchListenerDecorator(View.OnTouchListener decorated,
       EsriGGMapView esriGGMapView,
       Subject<MapDragEvent> subject,
       BiFunction<Float, Float, PointGeometry> screenToGround) {


### PR DESCRIPTION
Introduced MapDragEvent that represents drag motion movement over the map in world coordinates.
Added getMapDragEventObservable to GGMapView and implemented it at EsriGGMapView.
Made an example observer that prints those movements to the log at FreedrawActionFragment.

Changed free-draw-action-fragment to disable panning on startup.