### PR TITLE
Phase display action

### DIFF
--- a/app/src/main/java/com/teamagam/gimelgimel/app/common/base/ViewModels/BaseViewModel.java
+++ b/app/src/main/java/com/teamagam/gimelgimel/app/common/base/ViewModels/BaseViewModel.java
@@ -3,6 +3,7 @@ package com.teamagam.gimelgimel.app.common.base.ViewModels;
 import android.databinding.BaseObservable;
 import com.teamagam.gimelgimel.app.common.logging.AppLogger;
 import com.teamagam.gimelgimel.app.common.logging.AppLoggerFactory;
+import com.teamagam.gimelgimel.app.common.utils.InteractorUtils;
 import com.teamagam.gimelgimel.domain.base.interactors.Interactor;
 
 /**
@@ -41,26 +42,10 @@ public abstract class BaseViewModel<V> extends BaseObservable implements ViewMod
   }
 
   protected void execute(Interactor... interactors) {
-    for (Interactor interactor : interactors) {
-      execute(interactor);
-    }
+    InteractorUtils.execute(interactors);
   }
 
   protected void unsubscribe(Interactor... interactors) {
-    for (Interactor interactor : interactors) {
-      unsubscribe(interactor);
-    }
-  }
-
-  private void execute(Interactor interactor) {
-    if (interactor != null) {
-      interactor.execute();
-    }
-  }
-
-  private void unsubscribe(Interactor interactor) {
-    if (interactor != null) {
-      interactor.unsubscribe();
-    }
+    InteractorUtils.unsubscribe(interactors);
   }
 }

--- a/app/src/main/java/com/teamagam/gimelgimel/app/common/launcher/Navigator.java
+++ b/app/src/main/java/com/teamagam/gimelgimel/app/common/launcher/Navigator.java
@@ -8,7 +8,12 @@ import com.teamagam.gimelgimel.app.icons.OnIconSelectionListener;
 import com.teamagam.gimelgimel.app.location.GoToLocationDialogFragment;
 import com.teamagam.gimelgimel.app.location.TurnOnGpsDialogFragment;
 import com.teamagam.gimelgimel.app.mainActivity.view.MainActivityConnectivityAlerts;
-import com.teamagam.gimelgimel.app.map.actions.DrawActionActivity;
+import com.teamagam.gimelgimel.app.map.actions.freedraw.FreeDrawActionProvider;
+import com.teamagam.gimelgimel.app.map.actions.measure.MeasureActionProvider;
+import com.teamagam.gimelgimel.app.map.actions.send.dynamicLayers.EditDynamicLayerActionProvider;
+import com.teamagam.gimelgimel.app.map.actions.send.geometry.SendGeometryActionProvider;
+import com.teamagam.gimelgimel.app.map.actions.send.quadrilateral.SendQuadrilateralActionProvider;
+import com.teamagam.gimelgimel.app.map.actions.timeplay.TimeplayActionProvider;
 import com.teamagam.gimelgimel.app.message.view.ImageFullscreenActivity;
 import com.teamagam.gimelgimel.app.message.view.SendGeographicMessageDialog;
 import com.teamagam.gimelgimel.app.settings.SettingsActivity;
@@ -62,27 +67,27 @@ public class Navigator {
   }
 
   public void openSendQuadrilateralAction() {
-    DrawActionActivity.startSendQuadAction(mActivity);
+    SendQuadrilateralActionProvider.startSendQuadAction(mActivity);
   }
 
   public void openMeasureDistanceAction() {
-    DrawActionActivity.startMeasureAction(mActivity);
+    MeasureActionProvider.startMeasureAction(mActivity);
   }
 
   public void openSendGeometryAction() {
-    DrawActionActivity.startSendGeometryAction(mActivity);
+    SendGeometryActionProvider.startSendGeometryAction(mActivity);
   }
 
   public void openDynamicLayerEditAction(DynamicLayer dynamicLayer) {
-    DrawActionActivity.startDynamicLayerEditAction(mActivity, dynamicLayer);
+    EditDynamicLayerActionProvider.startDynamicLayerEditAction(mActivity, dynamicLayer);
   }
 
   public void openFreeDrawAction() {
-    DrawActionActivity.startFreeDrawAction(mActivity);
+    FreeDrawActionProvider.startFreeDrawAction(mActivity);
   }
 
   public void openTimeplayAction() {
-    DrawActionActivity.startTimeplayAction(mActivity);
+    TimeplayActionProvider.startTimeplayAction(mActivity);
   }
 
   public void openIconSelectionDialog(OnIconSelectionListener listener) {

--- a/app/src/main/java/com/teamagam/gimelgimel/app/common/launcher/Navigator.java
+++ b/app/src/main/java/com/teamagam/gimelgimel/app/common/launcher/Navigator.java
@@ -10,6 +10,7 @@ import com.teamagam.gimelgimel.app.location.TurnOnGpsDialogFragment;
 import com.teamagam.gimelgimel.app.mainActivity.view.MainActivityConnectivityAlerts;
 import com.teamagam.gimelgimel.app.map.actions.freedraw.FreeDrawActionProvider;
 import com.teamagam.gimelgimel.app.map.actions.measure.MeasureActionProvider;
+import com.teamagam.gimelgimel.app.map.actions.phase.PhaseActionProvider;
 import com.teamagam.gimelgimel.app.map.actions.send.dynamicLayers.EditDynamicLayerActionProvider;
 import com.teamagam.gimelgimel.app.map.actions.send.geometry.SendGeometryActionProvider;
 import com.teamagam.gimelgimel.app.map.actions.send.quadrilateral.SendQuadrilateralActionProvider;
@@ -19,6 +20,7 @@ import com.teamagam.gimelgimel.app.message.view.SendGeographicMessageDialog;
 import com.teamagam.gimelgimel.app.settings.SettingsActivity;
 import com.teamagam.gimelgimel.domain.dynamicLayers.entity.DynamicLayer;
 import com.teamagam.gimelgimel.domain.map.entities.geometries.PointGeometry;
+import com.teamagam.gimelgimel.domain.phase.visibility.PhaseLayerPresentation;
 import javax.inject.Inject;
 
 /**
@@ -92,5 +94,9 @@ public class Navigator {
 
   public void openIconSelectionDialog(OnIconSelectionListener listener) {
     IconSelectionDialogFragment.show(mActivity.getFragmentManager(), listener);
+  }
+
+  public void openPhaseAction(PhaseLayerPresentation phaseLayer) {
+    PhaseActionProvider.startPhaseAction(mActivity, phaseLayer.getId());
   }
 }

--- a/app/src/main/java/com/teamagam/gimelgimel/app/common/utils/InteractorUtils.java
+++ b/app/src/main/java/com/teamagam/gimelgimel/app/common/utils/InteractorUtils.java
@@ -2,10 +2,6 @@ package com.teamagam.gimelgimel.app.common.utils;
 
 import com.teamagam.gimelgimel.domain.base.interactors.Interactor;
 
-/**
- * TODO: add class summary notes
- */
-
 public class InteractorUtils {
 
   public static void execute(Interactor... interactors) {

--- a/app/src/main/java/com/teamagam/gimelgimel/app/common/utils/InteractorUtils.java
+++ b/app/src/main/java/com/teamagam/gimelgimel/app/common/utils/InteractorUtils.java
@@ -1,0 +1,46 @@
+package com.teamagam.gimelgimel.app.common.utils;
+
+import com.teamagam.gimelgimel.domain.base.interactors.Interactor;
+
+/**
+ * TODO: add class summary notes
+ */
+
+public class InteractorUtils {
+
+  public static void execute(Interactor... interactors) {
+    for (Interactor interactor : interactors) {
+      execute(interactor);
+    }
+  }
+
+  public static void execute(Iterable<Interactor> interactors) {
+    for (Interactor interactor : interactors) {
+      execute(interactor);
+    }
+  }
+
+  public static void unsubscribe(Iterable<Interactor> interactors) {
+    for (Interactor interactor : interactors) {
+      unsubscribe(interactor);
+    }
+  }
+
+  public static void unsubscribe(Interactor... interactors) {
+    for (Interactor interactor : interactors) {
+      unsubscribe(interactor);
+    }
+  }
+
+  private static void execute(Interactor interactor) {
+    if (interactor != null) {
+      interactor.execute();
+    }
+  }
+
+  private static void unsubscribe(Interactor interactor) {
+    if (interactor != null) {
+      interactor.unsubscribe();
+    }
+  }
+}

--- a/app/src/main/java/com/teamagam/gimelgimel/app/dynamic_layer/DynamicLayerDetailsFragment.java
+++ b/app/src/main/java/com/teamagam/gimelgimel/app/dynamic_layer/DynamicLayerDetailsFragment.java
@@ -44,12 +44,16 @@ public class DynamicLayerDetailsFragment
     // Required empty public constructor
   }
 
+  public static DynamicLayerDetailsFragment newInstance(String dynamicLayerId) {
+    return newInstance(dynamicLayerId, null);
+  }
+
   public static DynamicLayerDetailsFragment newInstance(String dynamicLayerId,
-      String dynamicEntityId) {
+      String preselectedEntityId) {
     DynamicLayerDetailsFragment fragment = new DynamicLayerDetailsFragment();
     Bundle args = new Bundle();
     args.putString(ARG_LAYER_ID, dynamicLayerId);
-    args.putString(ARG_ENTITY_ID, dynamicEntityId);
+    args.putString(ARG_ENTITY_ID, preselectedEntityId);
     fragment.setArguments(args);
     return fragment;
   }

--- a/app/src/main/java/com/teamagam/gimelgimel/app/dynamic_layer/DynamicLayerDetailsViewModel.java
+++ b/app/src/main/java/com/teamagam/gimelgimel/app/dynamic_layer/DynamicLayerDetailsViewModel.java
@@ -4,6 +4,8 @@ import android.view.View;
 import com.google.auto.factory.AutoFactory;
 import com.google.auto.factory.Provided;
 import com.teamagam.gimelgimel.app.common.base.ViewModels.BaseViewModel;
+import com.teamagam.gimelgimel.app.common.logging.AppLogger;
+import com.teamagam.gimelgimel.app.common.logging.AppLoggerFactory;
 import com.teamagam.gimelgimel.domain.dynamicLayers.DisplayDynamicLayerDetailsInteractor;
 import com.teamagam.gimelgimel.domain.dynamicLayers.DisplayDynamicLayerDetailsInteractorFactory;
 import com.teamagam.gimelgimel.domain.dynamicLayers.entity.DynamicEntity;
@@ -11,6 +13,8 @@ import com.teamagam.gimelgimel.domain.dynamicLayers.entity.DynamicLayer;
 
 @AutoFactory
 public class DynamicLayerDetailsViewModel extends BaseViewModel {
+
+  private static final AppLogger sLogger = AppLoggerFactory.create();
 
   private final DisplayDynamicLayerDetailsInteractorFactory mInteractorFactory;
   private final MasterListCallback mMasterListCallback;
@@ -28,7 +32,9 @@ public class DynamicLayerDetailsViewModel extends BaseViewModel {
       @Provided DisplayDynamicLayerDetailsInteractorFactory interactorFactory,
       MasterListCallback masterListCallback,
       DynamicLayerDetailsFragment.OnDynamicEntityClickedListener onDynamicEntityClickedListener,
-      DetailsStringProvider stringProvider, String dynamicLayerId, String dynamicEntityId) {
+      DetailsStringProvider stringProvider,
+      String dynamicLayerId,
+      String dynamicEntityId) {
     mInteractorFactory = interactorFactory;
     mMasterListCallback = masterListCallback;
     mOnDynamicEntityClickedListener = onDynamicEntityClickedListener;
@@ -85,6 +91,7 @@ public class DynamicLayerDetailsViewModel extends BaseViewModel {
   }
 
   private void onLayerListingClicked(DynamicLayer dynamicLayer) {
+    sLogger.userInteraction("Layer listing clicked - " + dynamicLayer);
     updateDescription(dynamicLayer.getDescription());
   }
 
@@ -94,6 +101,7 @@ public class DynamicLayerDetailsViewModel extends BaseViewModel {
   }
 
   private void onEntityListingClicked(DynamicEntity de) {
+    sLogger.userInteraction("Entity listing clicked - " + de);
     updateDescription(de.getDescription());
     mOnDynamicEntityClickedListener.onDynamicEntityListingClicked(de);
   }

--- a/app/src/main/java/com/teamagam/gimelgimel/app/injectors/components/ApplicationComponent.java
+++ b/app/src/main/java/com/teamagam/gimelgimel/app/injectors/components/ApplicationComponent.java
@@ -13,6 +13,7 @@ import com.teamagam.gimelgimel.app.injectors.modules.DatabaseModule;
 import com.teamagam.gimelgimel.app.injectors.modules.MessageModule;
 import com.teamagam.gimelgimel.app.injectors.modules.RepositoryModule;
 import com.teamagam.gimelgimel.app.injectors.modules.UtilsModule;
+import com.teamagam.gimelgimel.app.map.actions.DrawActionActivity;
 import com.teamagam.gimelgimel.app.map.actions.freedraw.FreeDrawActionFragment;
 import com.teamagam.gimelgimel.app.map.actions.measure.MeasureActionFragment;
 import com.teamagam.gimelgimel.app.map.actions.send.dynamicLayers.EditDynamicLayerActionFragment;
@@ -60,7 +61,6 @@ import com.teamagam.gimelgimel.domain.map.repository.DisplayedEntitiesRepository
 import com.teamagam.gimelgimel.domain.map.repository.GeoEntitiesRepository;
 import com.teamagam.gimelgimel.domain.map.repository.SelectedEntityRepository;
 import com.teamagam.gimelgimel.domain.map.repository.SingleDisplayedItemRepository;
-import com.teamagam.gimelgimel.domain.messages.AlertMessageTextFormatter;
 import com.teamagam.gimelgimel.domain.messages.ProcessMessagesInteractor;
 import com.teamagam.gimelgimel.domain.messages.SendMessageOnAvailableNetworkInteractor;
 import com.teamagam.gimelgimel.domain.messages.UpdateUnreadCountInteractor;
@@ -98,6 +98,8 @@ public interface ApplicationComponent {
   void inject(GGApplication ggApplication);
 
   void inject(ImageFullscreenActivity fullscreenActivity);
+
+  void inject(DrawActionActivity drawActionActivity);
 
   void inject(EsriGGMapView esriGGMapView);
 

--- a/app/src/main/java/com/teamagam/gimelgimel/app/injectors/components/ApplicationComponent.java
+++ b/app/src/main/java/com/teamagam/gimelgimel/app/injectors/components/ApplicationComponent.java
@@ -16,6 +16,7 @@ import com.teamagam.gimelgimel.app.injectors.modules.UtilsModule;
 import com.teamagam.gimelgimel.app.map.actions.DrawActionActivity;
 import com.teamagam.gimelgimel.app.map.actions.freedraw.FreeDrawActionFragment;
 import com.teamagam.gimelgimel.app.map.actions.measure.MeasureActionFragment;
+import com.teamagam.gimelgimel.app.map.actions.phase.PhaseActionFragment;
 import com.teamagam.gimelgimel.app.map.actions.send.dynamicLayers.EditDynamicLayerActionFragment;
 import com.teamagam.gimelgimel.app.map.actions.send.geometry.SendGeometryActionFragment;
 import com.teamagam.gimelgimel.app.map.actions.send.quadrilateral.SendQuadrilateralActionFragment;
@@ -118,6 +119,8 @@ public interface ApplicationComponent {
   void inject(IconSelectionDialogFragment iconSelectionDialogFragment);
 
   void inject(DynamicLayerDetailsFragment dynamicLayerDetailsFragment);
+
+  void inject(PhaseActionFragment phaseActionFragment);
 
   //Exposed to sub-graphs.
   Context context();

--- a/app/src/main/java/com/teamagam/gimelgimel/app/injectors/modules/UtilsModule.java
+++ b/app/src/main/java/com/teamagam/gimelgimel/app/injectors/modules/UtilsModule.java
@@ -8,6 +8,7 @@ import com.teamagam.gimelgimel.app.icons.IconProvider;
 import com.teamagam.gimelgimel.app.map.actions.ActionProvider;
 import com.teamagam.gimelgimel.app.map.actions.freedraw.FreeDrawActionProvider;
 import com.teamagam.gimelgimel.app.map.actions.measure.MeasureActionProvider;
+import com.teamagam.gimelgimel.app.map.actions.phase.PhaseActionProvider;
 import com.teamagam.gimelgimel.app.map.actions.send.geometry.SendGeometryActionProvider;
 import com.teamagam.gimelgimel.app.map.actions.send.quadrilateral.SendQuadrilateralActionProvider;
 import com.teamagam.gimelgimel.app.map.actions.timeplay.TimeplayActionProvider;
@@ -109,6 +110,7 @@ public class UtilsModule {
   @Provides
   Iterable<ActionProvider> provideActionProviders() {
     return Arrays.asList(new SendQuadrilateralActionProvider(), new SendGeometryActionProvider(),
-        new MeasureActionProvider(), new FreeDrawActionProvider(), new TimeplayActionProvider());
+        new MeasureActionProvider(), new FreeDrawActionProvider(), new TimeplayActionProvider(),
+        new PhaseActionProvider());
   }
 }

--- a/app/src/main/java/com/teamagam/gimelgimel/app/injectors/modules/UtilsModule.java
+++ b/app/src/main/java/com/teamagam/gimelgimel/app/injectors/modules/UtilsModule.java
@@ -5,6 +5,12 @@ import com.teamagam.gimelgimel.app.common.utils.Environment;
 import com.teamagam.gimelgimel.app.common.utils.GlideLoader;
 import com.teamagam.gimelgimel.app.icons.GlideIconProvider;
 import com.teamagam.gimelgimel.app.icons.IconProvider;
+import com.teamagam.gimelgimel.app.map.actions.ActionProvider;
+import com.teamagam.gimelgimel.app.map.actions.freedraw.FreeDrawActionProvider;
+import com.teamagam.gimelgimel.app.map.actions.measure.MeasureActionProvider;
+import com.teamagam.gimelgimel.app.map.actions.send.geometry.SendGeometryActionProvider;
+import com.teamagam.gimelgimel.app.map.actions.send.quadrilateral.SendQuadrilateralActionProvider;
+import com.teamagam.gimelgimel.app.map.actions.timeplay.TimeplayActionProvider;
 import com.teamagam.gimelgimel.data.layers.LayersLocalCacheData;
 import com.teamagam.gimelgimel.data.notifications.cellular_network.CellularNetworkTypeDataRepository;
 import com.teamagam.gimelgimel.data.rasters.IntermediateRastersLocalStorageData;
@@ -16,8 +22,8 @@ import com.teamagam.gimelgimel.data.timeplay.messages.GeoMessagesSnapshoter;
 import com.teamagam.gimelgimel.data.timeplay.messages.GeoMessagesTimespanCalculator;
 import com.teamagam.gimelgimel.data.timeplay.users.UserGeoSnapshoter;
 import com.teamagam.gimelgimel.data.timeplay.users.UsersGeoTimespanCalculator;
-import com.teamagam.gimelgimel.domain.layers.LayersLocalCache;
 import com.teamagam.gimelgimel.domain.dynamicLayers.details.DynamicLayerToEntityMapper;
+import com.teamagam.gimelgimel.domain.layers.LayersLocalCache;
 import com.teamagam.gimelgimel.domain.notifications.cellular_network.CellularNetworkTypeRepository;
 import com.teamagam.gimelgimel.domain.rasters.IntermediateRastersLocalStorage;
 import com.teamagam.gimelgimel.domain.timeplay.GeoSnapshoter;
@@ -27,6 +33,7 @@ import com.teamagam.gimelgimel.domain.utils.ApplicationStatus;
 import com.teamagam.gimelgimel.domain.utils.PreferencesUtils;
 import dagger.Module;
 import dagger.Provides;
+import java.util.Arrays;
 import javax.inject.Singleton;
 
 @Module
@@ -97,5 +104,11 @@ public class UtilsModule {
   @Singleton
   DynamicLayerToEntityMapper provideDynamicLayerToEntityMapper() {
     return new DynamicLayerToEntityMapper();
+  }
+
+  @Provides
+  Iterable<ActionProvider> provideActionProviders() {
+    return Arrays.asList(new SendQuadrilateralActionProvider(), new SendGeometryActionProvider(),
+        new MeasureActionProvider(), new FreeDrawActionProvider(), new TimeplayActionProvider());
   }
 }

--- a/app/src/main/java/com/teamagam/gimelgimel/app/injectors/modules/UtilsModule.java
+++ b/app/src/main/java/com/teamagam/gimelgimel/app/injectors/modules/UtilsModule.java
@@ -9,6 +9,7 @@ import com.teamagam.gimelgimel.app.map.actions.ActionProvider;
 import com.teamagam.gimelgimel.app.map.actions.freedraw.FreeDrawActionProvider;
 import com.teamagam.gimelgimel.app.map.actions.measure.MeasureActionProvider;
 import com.teamagam.gimelgimel.app.map.actions.phase.PhaseActionProvider;
+import com.teamagam.gimelgimel.app.map.actions.send.dynamicLayers.EditDynamicLayerActionProvider;
 import com.teamagam.gimelgimel.app.map.actions.send.geometry.SendGeometryActionProvider;
 import com.teamagam.gimelgimel.app.map.actions.send.quadrilateral.SendQuadrilateralActionProvider;
 import com.teamagam.gimelgimel.app.map.actions.timeplay.TimeplayActionProvider;
@@ -111,6 +112,6 @@ public class UtilsModule {
   Iterable<ActionProvider> provideActionProviders() {
     return Arrays.asList(new SendQuadrilateralActionProvider(), new SendGeometryActionProvider(),
         new MeasureActionProvider(), new FreeDrawActionProvider(), new TimeplayActionProvider(),
-        new PhaseActionProvider());
+        new PhaseActionProvider(), new EditDynamicLayerActionProvider());
   }
 }

--- a/app/src/main/java/com/teamagam/gimelgimel/app/mainActivity/drawer/layers/PhaseCategoryPresenter.java
+++ b/app/src/main/java/com/teamagam/gimelgimel/app/mainActivity/drawer/layers/PhaseCategoryPresenter.java
@@ -1,9 +1,13 @@
 package com.teamagam.gimelgimel.app.mainActivity.drawer.layers;
 
 import android.content.Context;
+import android.graphics.drawable.Drawable;
+import android.support.v4.content.ContextCompat;
+import android.support.v4.graphics.drawable.DrawableCompat;
 import com.google.auto.factory.AutoFactory;
 import com.google.auto.factory.Provided;
 import com.teamagam.gimelgimel.R;
+import com.teamagam.gimelgimel.app.common.launcher.Navigator;
 import com.teamagam.gimelgimel.data.base.repository.SubjectRepository;
 import com.teamagam.gimelgimel.domain.phase.PhaseLayer;
 import com.teamagam.gimelgimel.domain.phase.visibility.DisplayPhaseLayersInteractor;
@@ -19,6 +23,7 @@ public class PhaseCategoryPresenter extends DrawerCategoryPresenter<PhaseLayerPr
   private final OnPhaseLayerListingClickInteractorFactory
       mOnPhaseLayerListingClickInteractorFactory;
   private final Context mContext;
+  private final Navigator mNavigator;
   private final PhaseLayerNodeSelectionDisplayer mPhaseLayerNodeSelectionDisplayer;
   private final SubjectRepository<PhaseLayerPresentation> mSubject;
   private DisplayPhaseLayersInteractor mDisplayPhaseLayersInteractor;
@@ -26,11 +31,12 @@ public class PhaseCategoryPresenter extends DrawerCategoryPresenter<PhaseLayerPr
   protected PhaseCategoryPresenter(
       @Provided DisplayPhaseLayersInteractorFactory displayPhaseLayersInteractorFactory,
       @Provided OnPhaseLayerListingClickInteractorFactory onPhaseLayerListingClickInteractorFactory,
-      @Provided Context context,
+      @Provided Context context, @Provided Navigator navigator,
       LayersNodeDisplayer layersNodeDisplayer) {
     super(layersNodeDisplayer);
     mDisplayPhaseLayersInteractorFactory = displayPhaseLayersInteractorFactory;
     mContext = context;
+    mNavigator = navigator;
     mPhaseLayerNodeSelectionDisplayer = new PhaseLayerNodeSelectionDisplayer(layersNodeDisplayer);
     mOnPhaseLayerListingClickInteractorFactory = onPhaseLayerListingClickInteractorFactory;
     mSubject = SubjectRepository.createSimpleSubject();
@@ -75,6 +81,8 @@ public class PhaseCategoryPresenter extends DrawerCategoryPresenter<PhaseLayerPr
           parentNode.getId())
           .setIsSelected(phaseLayer.isShown())
           .setOnListingClickListener((v) -> onPhaseLayerListingClick(phaseLayer))
+          .setIcon(getWatchIcon())
+          .setOnIconClickListener((v) -> onWatchPhaseLayerClicked(phaseLayer))
           .createNode();
     }
 
@@ -85,6 +93,16 @@ public class PhaseCategoryPresenter extends DrawerCategoryPresenter<PhaseLayerPr
 
     private void onPhaseLayerListingClick(PhaseLayer phaseLayer) {
       mOnPhaseLayerListingClickInteractorFactory.create(phaseLayer.getId()).execute();
+    }
+
+    private Drawable getWatchIcon() {
+      Drawable d = ContextCompat.getDrawable(mContext, android.R.drawable.ic_dialog_info);
+      DrawableCompat.setTint(d, ContextCompat.getColor(mContext, R.color.drawer_layers_edit));
+      return d;
+    }
+
+    private void onWatchPhaseLayerClicked(PhaseLayerPresentation phaseLayer) {
+      mNavigator.openPhaseAction(phaseLayer);
     }
   }
 }

--- a/app/src/main/java/com/teamagam/gimelgimel/app/mainActivity/drawer/layers/PhaseCategoryPresenter.java
+++ b/app/src/main/java/com/teamagam/gimelgimel/app/mainActivity/drawer/layers/PhaseCategoryPresenter.java
@@ -5,26 +5,26 @@ import com.google.auto.factory.AutoFactory;
 import com.google.auto.factory.Provided;
 import com.teamagam.gimelgimel.R;
 import com.teamagam.gimelgimel.data.base.repository.SubjectRepository;
-import com.teamagam.gimelgimel.domain.phase.visibility.DisplayPhaseLayerInteractor;
-import com.teamagam.gimelgimel.domain.phase.visibility.DisplayPhaseLayerInteractorFactory;
+import com.teamagam.gimelgimel.domain.phase.visibility.DisplayPhaseLayersInteractor;
+import com.teamagam.gimelgimel.domain.phase.visibility.DisplayPhaseLayersInteractorFactory;
 import com.teamagam.gimelgimel.domain.phase.visibility.PhaseLayerPresentation;
 import io.reactivex.Observable;
 
 @AutoFactory
 public class PhaseCategoryPresenter extends DrawerCategoryPresenter<PhaseLayerPresentation> {
 
-  private final DisplayPhaseLayerInteractorFactory mDisplayPhaseLayerInteractorFactory;
+  private final DisplayPhaseLayersInteractorFactory mDisplayPhaseLayersInteractorFactory;
   private final Context mContext;
   private final PhaseLayerNodeSelectionDisplayer mPhaseLayerNodeSelectionDisplayer;
   private final SubjectRepository<PhaseLayerPresentation> mSubject;
-  private DisplayPhaseLayerInteractor mDisplayPhaseLayerInteractor;
+  private DisplayPhaseLayersInteractor mDisplayPhaseLayersInteractor;
 
   protected PhaseCategoryPresenter(
-      @Provided DisplayPhaseLayerInteractorFactory displayPhaseLayerInteractorFactory,
+      @Provided DisplayPhaseLayersInteractorFactory displayPhaseLayersInteractorFactory,
       @Provided Context context,
       LayersNodeDisplayer layersNodeDisplayer) {
     super(layersNodeDisplayer);
-    mDisplayPhaseLayerInteractorFactory = displayPhaseLayerInteractorFactory;
+    mDisplayPhaseLayersInteractorFactory = displayPhaseLayersInteractorFactory;
     mContext = context;
     mPhaseLayerNodeSelectionDisplayer = new PhaseLayerNodeSelectionDisplayer(layersNodeDisplayer);
     mSubject = SubjectRepository.createSimpleSubject();
@@ -32,13 +32,13 @@ public class PhaseCategoryPresenter extends DrawerCategoryPresenter<PhaseLayerPr
 
   @Override
   public void start() {
-    mDisplayPhaseLayerInteractor = mDisplayPhaseLayerInteractorFactory.create(mSubject::add);
-    mDisplayPhaseLayerInteractor.execute();
+    mDisplayPhaseLayersInteractor = mDisplayPhaseLayersInteractorFactory.create(mSubject::add);
+    mDisplayPhaseLayersInteractor.execute();
   }
 
   @Override
   public void stop() {
-    mDisplayPhaseLayerInteractor.unsubscribe();
+    mDisplayPhaseLayersInteractor.unsubscribe();
   }
 
   @Override

--- a/app/src/main/java/com/teamagam/gimelgimel/app/mainActivity/drawer/layers/PhaseCategoryPresenter.java
+++ b/app/src/main/java/com/teamagam/gimelgimel/app/mainActivity/drawer/layers/PhaseCategoryPresenter.java
@@ -5,8 +5,10 @@ import com.google.auto.factory.AutoFactory;
 import com.google.auto.factory.Provided;
 import com.teamagam.gimelgimel.R;
 import com.teamagam.gimelgimel.data.base.repository.SubjectRepository;
+import com.teamagam.gimelgimel.domain.phase.PhaseLayer;
 import com.teamagam.gimelgimel.domain.phase.visibility.DisplayPhaseLayersInteractor;
 import com.teamagam.gimelgimel.domain.phase.visibility.DisplayPhaseLayersInteractorFactory;
+import com.teamagam.gimelgimel.domain.phase.visibility.OnPhaseLayerListingClickInteractorFactory;
 import com.teamagam.gimelgimel.domain.phase.visibility.PhaseLayerPresentation;
 import io.reactivex.Observable;
 
@@ -14,6 +16,8 @@ import io.reactivex.Observable;
 public class PhaseCategoryPresenter extends DrawerCategoryPresenter<PhaseLayerPresentation> {
 
   private final DisplayPhaseLayersInteractorFactory mDisplayPhaseLayersInteractorFactory;
+  private final OnPhaseLayerListingClickInteractorFactory
+      mOnPhaseLayerListingClickInteractorFactory;
   private final Context mContext;
   private final PhaseLayerNodeSelectionDisplayer mPhaseLayerNodeSelectionDisplayer;
   private final SubjectRepository<PhaseLayerPresentation> mSubject;
@@ -21,12 +25,14 @@ public class PhaseCategoryPresenter extends DrawerCategoryPresenter<PhaseLayerPr
 
   protected PhaseCategoryPresenter(
       @Provided DisplayPhaseLayersInteractorFactory displayPhaseLayersInteractorFactory,
+      @Provided OnPhaseLayerListingClickInteractorFactory onPhaseLayerListingClickInteractorFactory,
       @Provided Context context,
       LayersNodeDisplayer layersNodeDisplayer) {
     super(layersNodeDisplayer);
     mDisplayPhaseLayersInteractorFactory = displayPhaseLayersInteractorFactory;
     mContext = context;
     mPhaseLayerNodeSelectionDisplayer = new PhaseLayerNodeSelectionDisplayer(layersNodeDisplayer);
+    mOnPhaseLayerListingClickInteractorFactory = onPhaseLayerListingClickInteractorFactory;
     mSubject = SubjectRepository.createSimpleSubject();
   }
 
@@ -56,23 +62,29 @@ public class PhaseCategoryPresenter extends DrawerCategoryPresenter<PhaseLayerPr
     return mPhaseLayerNodeSelectionDisplayer;
   }
 
-  private static class PhaseLayerNodeSelectionDisplayer
+  private class PhaseLayerNodeSelectionDisplayer
       extends NodeSelectionDisplayer<PhaseLayerPresentation> {
     public PhaseLayerNodeSelectionDisplayer(LayersNodeDisplayer layersNodeDisplayer) {
       super(layersNodeDisplayer);
     }
 
     @Override
-    protected LayersNodeDisplayer.Node createNode(PhaseLayerPresentation item,
+    protected LayersNodeDisplayer.Node createNode(PhaseLayerPresentation phaseLayer,
         LayersNodeDisplayer.Node parentNode) {
-      return new LayersNodeDisplayer.NodeBuilder(item.getName()).setParentId(parentNode.getId())
-          .setIsSelected(item.isShown())
+      return new LayersNodeDisplayer.NodeBuilder(phaseLayer.getName()).setParentId(
+          parentNode.getId())
+          .setIsSelected(phaseLayer.isShown())
+          .setOnListingClickListener((v) -> onPhaseLayerListingClick(phaseLayer))
           .createNode();
     }
 
     @Override
     protected boolean isSelected(PhaseLayerPresentation item) {
       return item.isShown();
+    }
+
+    private void onPhaseLayerListingClick(PhaseLayer phaseLayer) {
+      mOnPhaseLayerListingClickInteractorFactory.create(phaseLayer.getId()).execute();
     }
   }
 }

--- a/app/src/main/java/com/teamagam/gimelgimel/app/map/BaseMapViewModel.java
+++ b/app/src/main/java/com/teamagam/gimelgimel/app/map/BaseMapViewModel.java
@@ -1,50 +1,17 @@
 package com.teamagam.gimelgimel.app.map;
 
 import com.teamagam.gimelgimel.app.common.base.ViewModels.BaseViewModel;
-import com.teamagam.gimelgimel.domain.dynamicLayers.DisplayDynamicLayersInteractor;
-import com.teamagam.gimelgimel.domain.dynamicLayers.DisplayDynamicLayersInteractorFactory;
-import com.teamagam.gimelgimel.domain.dynamicLayers.DynamicLayerPresentation;
-import com.teamagam.gimelgimel.domain.dynamicLayers.entity.DynamicEntity;
-import com.teamagam.gimelgimel.domain.dynamicLayers.entity.DynamicLayer;
-import com.teamagam.gimelgimel.domain.layers.DisplayVectorLayersInteractor;
-import com.teamagam.gimelgimel.domain.layers.DisplayVectorLayersInteractorFactory;
-import com.teamagam.gimelgimel.domain.layers.entitiy.VectorLayerPresentation;
-import com.teamagam.gimelgimel.domain.map.DisplayMapEntitiesInteractor;
-import com.teamagam.gimelgimel.domain.map.DisplayMapEntitiesInteractorFactory;
-import com.teamagam.gimelgimel.domain.map.entities.mapEntities.GeoEntity;
-import com.teamagam.gimelgimel.domain.notifications.entity.GeoEntityNotification;
-import com.teamagam.gimelgimel.domain.rasters.DisplayIntermediateRastersInteractor;
-import com.teamagam.gimelgimel.domain.rasters.DisplayIntermediateRastersInteractorFactory;
-import com.teamagam.gimelgimel.domain.rasters.IntermediateRasterPresentation;
-import io.reactivex.functions.Function;
-import java.util.HashMap;
-import java.util.Map;
 
 public class BaseMapViewModel<V> extends BaseViewModel<V> {
 
-  private final DisplayMapEntitiesInteractorFactory mMapEntitiesInteractorFactory;
-  private final DisplayVectorLayersInteractorFactory mDisplayVectorLayersInteractorFactory;
-  private final DisplayDynamicLayersInteractorFactory mDisplayDynamicLayersInteractorFactory;
-  private final DisplayIntermediateRastersInteractorFactory
-      mDisplayIntermediateRastersInteractorFactory;
-
   private final GGMapView mGGMapView;
+  private final MapEntitiesDisplayer mMapEntitiesDisplayer;
 
-  private DisplayMapEntitiesInteractor mDisplayMapEntitiesInteractor;
-  private DisplayVectorLayersInteractor mDisplayVectorLayersInteractor;
-  private DisplayDynamicLayersInteractor mDisplayDynamicLayersInteractor;
-  private DisplayIntermediateRastersInteractor mDisplayIntermediateRastersInteractor;
   private boolean mIsSubscribedToOnReady;
 
-  protected BaseMapViewModel(DisplayMapEntitiesInteractorFactory displayMapEntitiesInteractorFactory,
-      DisplayVectorLayersInteractorFactory displayVectorLayersInteractorFactory,
-      DisplayDynamicLayersInteractorFactory displayDynamicLayersInteractorFactory,
-      DisplayIntermediateRastersInteractorFactory displayIntermediateRastersInteractorFactory,
+  protected BaseMapViewModel(MapEntitiesDisplayerFactory mapEntitiesDisplayerFactory,
       GGMapView ggMapView) {
-    mMapEntitiesInteractorFactory = displayMapEntitiesInteractorFactory;
-    mDisplayVectorLayersInteractorFactory = displayVectorLayersInteractorFactory;
-    mDisplayDynamicLayersInteractorFactory = displayDynamicLayersInteractorFactory;
-    mDisplayIntermediateRastersInteractorFactory = displayIntermediateRastersInteractorFactory;
+    mMapEntitiesDisplayer = mapEntitiesDisplayerFactory.create(ggMapView);
     mGGMapView = ggMapView;
     mIsSubscribedToOnReady = false;
   }
@@ -64,8 +31,7 @@ public class BaseMapViewModel<V> extends BaseViewModel<V> {
   @Override
   public void destroy() {
     super.destroy();
-    unsubscribe(mDisplayMapEntitiesInteractor, mDisplayIntermediateRastersInteractor,
-        mDisplayVectorLayersInteractor, mDisplayDynamicLayersInteractor);
+    mMapEntitiesDisplayer.stop();
     unsubscribeToOnReady();
   }
 
@@ -77,83 +43,11 @@ public class BaseMapViewModel<V> extends BaseViewModel<V> {
   }
 
   private void onMapReady() {
-    initializeInteractors();
-    execute(mDisplayMapEntitiesInteractor, mDisplayIntermediateRastersInteractor,
-        mDisplayVectorLayersInteractor, mDisplayDynamicLayersInteractor);
-  }
-
-  private void initializeInteractors() {
-    mDisplayMapEntitiesInteractor =
-        mMapEntitiesInteractorFactory.create(mGGMapView::updateMapEntity);
-
-    mDisplayVectorLayersInteractor =
-        mDisplayVectorLayersInteractorFactory.create(new VectorLayersInteractorDisplayer());
-
-    mDisplayDynamicLayersInteractor =
-        mDisplayDynamicLayersInteractorFactory.create(new DynamicLayersInteractorDisplayer());
-
-    mDisplayIntermediateRastersInteractor =
-        mDisplayIntermediateRastersInteractorFactory.create(new IntermediateRastersDisplayer());
+    mMapEntitiesDisplayer.start();
   }
 
   private void unsubscribeToOnReady() {
     mGGMapView.setOnReadyListener(null);
     mIsSubscribedToOnReady = false;
-  }
-
-  class VectorLayersInteractorDisplayer implements DisplayVectorLayersInteractor.Displayer {
-    @Override
-    public void display(VectorLayerPresentation vlp) {
-      if (vlp.isShown()) {
-        mGGMapView.showVectorLayer(vlp);
-      } else {
-        mGGMapView.hideVectorLayer(vlp.getId());
-      }
-    }
-  }
-
-  class DynamicLayersInteractorDisplayer implements DisplayDynamicLayersInteractor.Displayer {
-    Map<String, DynamicLayer> mIdToDisplayedDynamicLayerMap = new HashMap<>();
-
-    @Override
-    public void display(DynamicLayerPresentation dl) {
-      String id = dl.getId();
-      hideDynamicLayerEntities(id);
-      if (dl.isShown()) {
-        showDynamicLayerEntities(dl, id);
-      }
-    }
-
-    private void hideDynamicLayerEntities(String dynamicLayerId) {
-      if (mIdToDisplayedDynamicLayerMap.containsKey(dynamicLayerId)) {
-        updateEntitiesOnMap(dynamicLayerId, GeoEntityNotification::createRemove);
-      }
-    }
-
-    private void updateEntitiesOnMap(String id,
-        Function<GeoEntity, GeoEntityNotification> creator) {
-      for (DynamicEntity entity : mIdToDisplayedDynamicLayerMap.get(id).getEntities()) {
-        try {
-          mGGMapView.updateMapEntity(creator.apply(entity.getGeoEntity()));
-        } catch (Exception ignored) {
-        }
-      }
-    }
-
-    private void showDynamicLayerEntities(DynamicLayerPresentation dl, String id) {
-      mIdToDisplayedDynamicLayerMap.put(id, dl);
-      updateEntitiesOnMap(id, GeoEntityNotification::createAdd);
-    }
-  }
-
-  class IntermediateRastersDisplayer implements DisplayIntermediateRastersInteractor.Displayer {
-    @Override
-    public void display(IntermediateRasterPresentation intermediateRasterPresentation) {
-      if (intermediateRasterPresentation.isShown()) {
-        mGGMapView.setIntermediateRaster(intermediateRasterPresentation);
-      } else {
-        mGGMapView.removeIntermediateRaster();
-      }
-    }
   }
 }

--- a/app/src/main/java/com/teamagam/gimelgimel/app/map/BaseMapViewModel.java
+++ b/app/src/main/java/com/teamagam/gimelgimel/app/map/BaseMapViewModel.java
@@ -34,6 +34,7 @@ public class BaseMapViewModel<V> extends BaseViewModel<V> {
   private DisplayVectorLayersInteractor mDisplayVectorLayersInteractor;
   private DisplayDynamicLayersInteractor mDisplayDynamicLayersInteractor;
   private DisplayIntermediateRastersInteractor mDisplayIntermediateRastersInteractor;
+  private boolean mIsSubscribedToOnReady;
 
   protected BaseMapViewModel(DisplayMapEntitiesInteractorFactory displayMapEntitiesInteractorFactory,
       DisplayVectorLayersInteractorFactory displayVectorLayersInteractorFactory,
@@ -45,12 +46,19 @@ public class BaseMapViewModel<V> extends BaseViewModel<V> {
     mDisplayDynamicLayersInteractorFactory = displayDynamicLayersInteractorFactory;
     mDisplayIntermediateRastersInteractorFactory = displayIntermediateRastersInteractorFactory;
     mGGMapView = ggMapView;
+    mIsSubscribedToOnReady = false;
   }
 
   @Override
   public void init() {
     super.init();
-    mGGMapView.setOnReadyListener(this::onMapReady);
+    subscribeToOnReady();
+  }
+
+  @Override
+  public void start() {
+    super.start();
+    subscribeToOnReady();
   }
 
   @Override
@@ -58,7 +66,14 @@ public class BaseMapViewModel<V> extends BaseViewModel<V> {
     super.destroy();
     unsubscribe(mDisplayMapEntitiesInteractor, mDisplayIntermediateRastersInteractor,
         mDisplayVectorLayersInteractor, mDisplayDynamicLayersInteractor);
-    mGGMapView.setOnReadyListener(null);
+    unsubscribeToOnReady();
+  }
+
+  private void subscribeToOnReady() {
+    if (!mIsSubscribedToOnReady) {
+      mGGMapView.setOnReadyListener(this::onMapReady);
+      mIsSubscribedToOnReady = true;
+    }
   }
 
   private void onMapReady() {
@@ -79,6 +94,11 @@ public class BaseMapViewModel<V> extends BaseViewModel<V> {
 
     mDisplayIntermediateRastersInteractor =
         mDisplayIntermediateRastersInteractorFactory.create(new IntermediateRastersDisplayer());
+  }
+
+  private void unsubscribeToOnReady() {
+    mGGMapView.setOnReadyListener(null);
+    mIsSubscribedToOnReady = false;
   }
 
   class VectorLayersInteractorDisplayer implements DisplayVectorLayersInteractor.Displayer {

--- a/app/src/main/java/com/teamagam/gimelgimel/app/map/DynamicLayersMapDisplayer.java
+++ b/app/src/main/java/com/teamagam/gimelgimel/app/map/DynamicLayersMapDisplayer.java
@@ -1,0 +1,50 @@
+package com.teamagam.gimelgimel.app.map;
+
+import com.teamagam.gimelgimel.domain.dynamicLayers.DisplayDynamicLayersInteractor;
+import com.teamagam.gimelgimel.domain.dynamicLayers.DynamicLayerPresentation;
+import com.teamagam.gimelgimel.domain.dynamicLayers.entity.DynamicEntity;
+import com.teamagam.gimelgimel.domain.dynamicLayers.entity.DynamicLayer;
+import com.teamagam.gimelgimel.domain.map.entities.mapEntities.GeoEntity;
+import com.teamagam.gimelgimel.domain.notifications.entity.GeoEntityNotification;
+import io.reactivex.functions.Function;
+import java.util.HashMap;
+import java.util.Map;
+
+public class DynamicLayersMapDisplayer implements DisplayDynamicLayersInteractor.Displayer {
+  private final Map<String, DynamicLayer> mIdToDisplayedDynamicLayerMap;
+  private final GGMapView mGGMapView;
+
+  public DynamicLayersMapDisplayer(GGMapView GGMapView) {
+    mGGMapView = GGMapView;
+    mIdToDisplayedDynamicLayerMap = new HashMap<>();
+  }
+
+  @Override
+  public void display(DynamicLayerPresentation dl) {
+    String id = dl.getId();
+    hideDynamicLayerEntities(id);
+    if (dl.isShown()) {
+      showDynamicLayerEntities(dl, id);
+    }
+  }
+
+  private void hideDynamicLayerEntities(String dynamicLayerId) {
+    if (mIdToDisplayedDynamicLayerMap.containsKey(dynamicLayerId)) {
+      updateEntitiesOnMap(dynamicLayerId, GeoEntityNotification::createRemove);
+    }
+  }
+
+  private void updateEntitiesOnMap(String id, Function<GeoEntity, GeoEntityNotification> creator) {
+    for (DynamicEntity entity : mIdToDisplayedDynamicLayerMap.get(id).getEntities()) {
+      try {
+        mGGMapView.updateMapEntity(creator.apply(entity.getGeoEntity()));
+      } catch (Exception ignored) {
+      }
+    }
+  }
+
+  private void showDynamicLayerEntities(DynamicLayerPresentation dl, String id) {
+    mIdToDisplayedDynamicLayerMap.put(id, dl);
+    updateEntitiesOnMap(id, GeoEntityNotification::createAdd);
+  }
+}

--- a/app/src/main/java/com/teamagam/gimelgimel/app/map/MapEntitiesDisplayer.java
+++ b/app/src/main/java/com/teamagam/gimelgimel/app/map/MapEntitiesDisplayer.java
@@ -1,0 +1,148 @@
+package com.teamagam.gimelgimel.app.map;
+
+import com.google.auto.factory.AutoFactory;
+import com.google.auto.factory.Provided;
+import com.teamagam.gimelgimel.app.common.utils.InteractorUtils;
+import com.teamagam.gimelgimel.domain.base.interactors.Interactor;
+import com.teamagam.gimelgimel.domain.dynamicLayers.DisplayDynamicLayersInteractor;
+import com.teamagam.gimelgimel.domain.dynamicLayers.DisplayDynamicLayersInteractorFactory;
+import com.teamagam.gimelgimel.domain.dynamicLayers.DynamicLayerPresentation;
+import com.teamagam.gimelgimel.domain.dynamicLayers.entity.DynamicEntity;
+import com.teamagam.gimelgimel.domain.dynamicLayers.entity.DynamicLayer;
+import com.teamagam.gimelgimel.domain.layers.DisplayVectorLayersInteractor;
+import com.teamagam.gimelgimel.domain.layers.DisplayVectorLayersInteractorFactory;
+import com.teamagam.gimelgimel.domain.layers.entitiy.VectorLayerPresentation;
+import com.teamagam.gimelgimel.domain.map.DisplayMapEntitiesInteractorFactory;
+import com.teamagam.gimelgimel.domain.map.entities.mapEntities.GeoEntity;
+import com.teamagam.gimelgimel.domain.notifications.entity.GeoEntityNotification;
+import com.teamagam.gimelgimel.domain.phase.visibility.DisplayPhaseLayersInteractorFactory;
+import com.teamagam.gimelgimel.domain.rasters.DisplayIntermediateRastersInteractor;
+import com.teamagam.gimelgimel.domain.rasters.DisplayIntermediateRastersInteractorFactory;
+import com.teamagam.gimelgimel.domain.rasters.IntermediateRasterPresentation;
+import io.reactivex.functions.Function;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@AutoFactory
+public class MapEntitiesDisplayer {
+
+  private final DisplayMapEntitiesInteractorFactory mDisplayMapEntitiesInteractorFactory;
+  private final DisplayVectorLayersInteractorFactory mDisplayVectorLayersInteractorFactory;
+  private final DisplayDynamicLayersInteractorFactory mDisplayDynamicLayersInteractorFactory;
+  private final DisplayIntermediateRastersInteractorFactory
+      mDisplayIntermediateRastersInteractorFactory;
+  private final DisplayPhaseLayersInteractorFactory mDisplayPhaseLayersInteractorFactory;
+  private final GGMapView mGGMapView;
+  private final List<Interactor> mInteractors;
+
+  MapEntitiesDisplayer(
+      @Provided DisplayMapEntitiesInteractorFactory displayMapEntitiesInteractorFactory,
+      @Provided DisplayVectorLayersInteractorFactory displayVectorLayersInteractorFactory,
+      @Provided DisplayDynamicLayersInteractorFactory displayDynamicLayersInteractorFactory,
+      @Provided
+          DisplayIntermediateRastersInteractorFactory displayIntermediateRastersInteractorFactory,
+      @Provided DisplayPhaseLayersInteractorFactory displayPhaseLayersInteractorFactory,
+      GGMapView ggMapView) {
+    mDisplayMapEntitiesInteractorFactory = displayMapEntitiesInteractorFactory;
+    mDisplayVectorLayersInteractorFactory = displayVectorLayersInteractorFactory;
+    mDisplayDynamicLayersInteractorFactory = displayDynamicLayersInteractorFactory;
+    mDisplayIntermediateRastersInteractorFactory = displayIntermediateRastersInteractorFactory;
+    mDisplayPhaseLayersInteractorFactory = displayPhaseLayersInteractorFactory;
+    mGGMapView = ggMapView;
+    mInteractors = new ArrayList<>();
+  }
+
+  public void start() {
+    initializeInteractors();
+    InteractorUtils.execute(mInteractors);
+  }
+
+  public void stop() {
+    InteractorUtils.unsubscribe(mInteractors);
+  }
+
+  private void initializeInteractors() {
+    mInteractors.add(mDisplayMapEntitiesInteractorFactory.create(mGGMapView::updateMapEntity));
+
+    mInteractors.add(
+        mDisplayVectorLayersInteractorFactory.create(new VectorLayersInteractorDisplayer()));
+
+    DynamicLayersInteractorDisplayer dlDisplayer = new DynamicLayersInteractorDisplayer(mGGMapView);
+    mInteractors.add(mDisplayDynamicLayersInteractorFactory.create(dlDisplayer));
+
+    mInteractors.add(
+        mDisplayIntermediateRastersInteractorFactory.create(new IntermediateRastersDisplayer()));
+
+    mInteractors.add(mDisplayPhaseLayersInteractorFactory.create(plp -> {
+      for (DynamicLayer dl : plp.getPhases()) {
+        dlDisplayer.display(new DynamicLayerPresentation(dl, plp.isShown()));
+      }
+    }));
+  }
+
+  public static class DynamicLayersInteractorDisplayer
+      implements DisplayDynamicLayersInteractor.Displayer {
+    Map<String, DynamicLayer> mIdToDisplayedDynamicLayerMap;
+    private GGMapView mGGMapView;
+
+    public DynamicLayersInteractorDisplayer(GGMapView GGMapView) {
+      mGGMapView = GGMapView;
+      mIdToDisplayedDynamicLayerMap = new HashMap<>();
+    }
+
+    @Override
+    public void display(DynamicLayerPresentation dl) {
+      String id = dl.getId();
+      hideDynamicLayerEntities(id);
+      if (dl.isShown()) {
+        showDynamicLayerEntities(dl, id);
+      }
+    }
+
+    private void hideDynamicLayerEntities(String dynamicLayerId) {
+      if (mIdToDisplayedDynamicLayerMap.containsKey(dynamicLayerId)) {
+        updateEntitiesOnMap(dynamicLayerId, GeoEntityNotification::createRemove);
+      }
+    }
+
+    private void updateEntitiesOnMap(String id,
+        Function<GeoEntity, GeoEntityNotification> creator) {
+      for (DynamicEntity entity : mIdToDisplayedDynamicLayerMap.get(id).getEntities()) {
+        try {
+          mGGMapView.updateMapEntity(creator.apply(entity.getGeoEntity()));
+        } catch (Exception ignored) {
+        }
+      }
+    }
+
+    private void showDynamicLayerEntities(DynamicLayerPresentation dl, String id) {
+      mIdToDisplayedDynamicLayerMap.put(id, dl);
+      updateEntitiesOnMap(id, GeoEntityNotification::createAdd);
+    }
+  }
+
+  private class VectorLayersInteractorDisplayer implements DisplayVectorLayersInteractor.Displayer {
+    @Override
+    public void display(VectorLayerPresentation vlp) {
+      if (vlp.isShown()) {
+        mGGMapView.showVectorLayer(vlp);
+      } else {
+        mGGMapView.hideVectorLayer(vlp.getId());
+      }
+    }
+  }
+
+  private class IntermediateRastersDisplayer
+      implements DisplayIntermediateRastersInteractor.Displayer {
+    @Override
+    public void display(IntermediateRasterPresentation intermediateRasterPresentation) {
+      if (intermediateRasterPresentation.isShown()) {
+        mGGMapView.setIntermediateRaster(intermediateRasterPresentation);
+      } else {
+        mGGMapView.removeIntermediateRaster();
+      }
+    }
+  }
+}

--- a/app/src/main/java/com/teamagam/gimelgimel/app/map/MapEntitiesDisplayer.java
+++ b/app/src/main/java/com/teamagam/gimelgimel/app/map/MapEntitiesDisplayer.java
@@ -4,26 +4,19 @@ import com.google.auto.factory.AutoFactory;
 import com.google.auto.factory.Provided;
 import com.teamagam.gimelgimel.app.common.utils.InteractorUtils;
 import com.teamagam.gimelgimel.domain.base.interactors.Interactor;
-import com.teamagam.gimelgimel.domain.dynamicLayers.DisplayDynamicLayersInteractor;
 import com.teamagam.gimelgimel.domain.dynamicLayers.DisplayDynamicLayersInteractorFactory;
 import com.teamagam.gimelgimel.domain.dynamicLayers.DynamicLayerPresentation;
-import com.teamagam.gimelgimel.domain.dynamicLayers.entity.DynamicEntity;
 import com.teamagam.gimelgimel.domain.dynamicLayers.entity.DynamicLayer;
 import com.teamagam.gimelgimel.domain.layers.DisplayVectorLayersInteractor;
 import com.teamagam.gimelgimel.domain.layers.DisplayVectorLayersInteractorFactory;
 import com.teamagam.gimelgimel.domain.layers.entitiy.VectorLayerPresentation;
 import com.teamagam.gimelgimel.domain.map.DisplayMapEntitiesInteractorFactory;
-import com.teamagam.gimelgimel.domain.map.entities.mapEntities.GeoEntity;
-import com.teamagam.gimelgimel.domain.notifications.entity.GeoEntityNotification;
 import com.teamagam.gimelgimel.domain.phase.visibility.DisplayPhaseLayersInteractorFactory;
 import com.teamagam.gimelgimel.domain.rasters.DisplayIntermediateRastersInteractor;
 import com.teamagam.gimelgimel.domain.rasters.DisplayIntermediateRastersInteractorFactory;
 import com.teamagam.gimelgimel.domain.rasters.IntermediateRasterPresentation;
-import io.reactivex.functions.Function;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 @AutoFactory
 public class MapEntitiesDisplayer {
@@ -69,7 +62,7 @@ public class MapEntitiesDisplayer {
     mInteractors.add(
         mDisplayVectorLayersInteractorFactory.create(new VectorLayersInteractorDisplayer()));
 
-    DynamicLayersInteractorDisplayer dlDisplayer = new DynamicLayersInteractorDisplayer(mGGMapView);
+    DynamicLayersMapDisplayer dlDisplayer = new DynamicLayersMapDisplayer(mGGMapView);
     mInteractors.add(mDisplayDynamicLayersInteractorFactory.create(dlDisplayer));
 
     mInteractors.add(
@@ -80,47 +73,6 @@ public class MapEntitiesDisplayer {
         dlDisplayer.display(new DynamicLayerPresentation(dl, plp.isShown()));
       }
     }));
-  }
-
-  public static class DynamicLayersInteractorDisplayer
-      implements DisplayDynamicLayersInteractor.Displayer {
-    Map<String, DynamicLayer> mIdToDisplayedDynamicLayerMap;
-    private GGMapView mGGMapView;
-
-    public DynamicLayersInteractorDisplayer(GGMapView GGMapView) {
-      mGGMapView = GGMapView;
-      mIdToDisplayedDynamicLayerMap = new HashMap<>();
-    }
-
-    @Override
-    public void display(DynamicLayerPresentation dl) {
-      String id = dl.getId();
-      hideDynamicLayerEntities(id);
-      if (dl.isShown()) {
-        showDynamicLayerEntities(dl, id);
-      }
-    }
-
-    private void hideDynamicLayerEntities(String dynamicLayerId) {
-      if (mIdToDisplayedDynamicLayerMap.containsKey(dynamicLayerId)) {
-        updateEntitiesOnMap(dynamicLayerId, GeoEntityNotification::createRemove);
-      }
-    }
-
-    private void updateEntitiesOnMap(String id,
-        Function<GeoEntity, GeoEntityNotification> creator) {
-      for (DynamicEntity entity : mIdToDisplayedDynamicLayerMap.get(id).getEntities()) {
-        try {
-          mGGMapView.updateMapEntity(creator.apply(entity.getGeoEntity()));
-        } catch (Exception ignored) {
-        }
-      }
-    }
-
-    private void showDynamicLayerEntities(DynamicLayerPresentation dl, String id) {
-      mIdToDisplayedDynamicLayerMap.put(id, dl);
-      updateEntitiesOnMap(id, GeoEntityNotification::createAdd);
-    }
   }
 
   private class VectorLayersInteractorDisplayer implements DisplayVectorLayersInteractor.Displayer {

--- a/app/src/main/java/com/teamagam/gimelgimel/app/map/actions/ActionProvider.java
+++ b/app/src/main/java/com/teamagam/gimelgimel/app/map/actions/ActionProvider.java
@@ -1,0 +1,10 @@
+package com.teamagam.gimelgimel.app.map.actions;
+
+import android.os.Bundle;
+
+public interface ActionProvider {
+
+  String getActionTag();
+
+  BaseDrawActionFragment createActionFragment(Bundle bundle);
+}

--- a/app/src/main/java/com/teamagam/gimelgimel/app/map/actions/BaseGeometryStyleViewModel.java
+++ b/app/src/main/java/com/teamagam/gimelgimel/app/map/actions/BaseGeometryStyleViewModel.java
@@ -7,10 +7,7 @@ import com.teamagam.gimelgimel.BR;
 import com.teamagam.gimelgimel.R;
 import com.teamagam.gimelgimel.app.map.BaseMapViewModel;
 import com.teamagam.gimelgimel.app.map.GGMapView;
-import com.teamagam.gimelgimel.domain.dynamicLayers.DisplayDynamicLayersInteractorFactory;
-import com.teamagam.gimelgimel.domain.layers.DisplayVectorLayersInteractorFactory;
-import com.teamagam.gimelgimel.domain.map.DisplayMapEntitiesInteractorFactory;
-import com.teamagam.gimelgimel.domain.rasters.DisplayIntermediateRastersInteractorFactory;
+import com.teamagam.gimelgimel.app.map.MapEntitiesDisplayerFactory;
 import io.reactivex.functions.Consumer;
 
 public abstract class BaseGeometryStyleViewModel extends BaseMapViewModel {
@@ -25,17 +22,12 @@ public abstract class BaseGeometryStyleViewModel extends BaseMapViewModel {
 
   private boolean mIsBorderColorPicking;
 
-  public BaseGeometryStyleViewModel(DisplayMapEntitiesInteractorFactory displayMapEntitiesInteractorFactory,
-      DisplayVectorLayersInteractorFactory displayVectorLayersInteractorFactory,
-      DisplayDynamicLayersInteractorFactory displayDynamicLayersInteractorFactory,
-      DisplayIntermediateRastersInteractorFactory displayIntermediateRastersInteractorFactory,
+  public BaseGeometryStyleViewModel(MapEntitiesDisplayerFactory mapEntitiesDisplayerFactory,
       Context context,
       GGMapView ggMapView,
       Consumer<Integer> pickColor,
       Consumer<String> pickBorderStyle) {
-    super(displayMapEntitiesInteractorFactory, displayVectorLayersInteractorFactory,
-        displayDynamicLayersInteractorFactory, displayIntermediateRastersInteractorFactory,
-        ggMapView);
+    super(mapEntitiesDisplayerFactory, ggMapView);
     mPickColor = pickColor;
     mIsBorderColorPicking = false;
     mPickBorderStyle = pickBorderStyle;

--- a/app/src/main/java/com/teamagam/gimelgimel/app/map/actions/DrawActionActivity.java
+++ b/app/src/main/java/com/teamagam/gimelgimel/app/map/actions/DrawActionActivity.java
@@ -5,67 +5,32 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.support.v7.widget.Toolbar;
 import butterknife.BindView;
+import com.google.common.collect.Iterables;
 import com.teamagam.gimelgimel.R;
 import com.teamagam.gimelgimel.app.GGApplication;
 import com.teamagam.gimelgimel.app.common.base.view.activity.BaseActivity;
 import com.teamagam.gimelgimel.app.common.logging.AppLoggerFactory;
-import com.teamagam.gimelgimel.app.map.actions.freedraw.FreeDrawActionFragment;
-import com.teamagam.gimelgimel.app.map.actions.measure.MeasureActionFragment;
-import com.teamagam.gimelgimel.app.map.actions.send.dynamicLayers.EditDynamicLayerActionFragment;
-import com.teamagam.gimelgimel.app.map.actions.send.geometry.SendGeometryActionFragment;
-import com.teamagam.gimelgimel.app.map.actions.send.quadrilateral.SendQuadrilateralActionFragment;
-import com.teamagam.gimelgimel.app.map.actions.timeplay.TimeplayActionFragment;
 import com.teamagam.gimelgimel.domain.base.logging.Logger;
-import com.teamagam.gimelgimel.domain.dynamicLayers.entity.DynamicLayer;
+import javax.inject.Inject;
 
 public class DrawActionActivity extends BaseActivity<GGApplication> {
 
   private static final Logger sLogger = AppLoggerFactory.create();
 
   private static final String ACTION_TAG = "action";
-  private static final String SEND_QUAD_ACTION = "send_quad";
-  private static final String MEASURE_DISTANCE_ACTION = "measure";
-  private static final String SEND_GEOMETRY_ACTION = "send_geometry";
-  private static final String EDIT_DYNAMIC_LAYER = "edit_dynamic_layer";
-  private static final String FREE_DRAW_ACTION = "free_draw";
-  private static final String TIMEPLAY_ACTION = "timeplay";
-  private static final String DYNAMIC_LAYER_ID_KEY = "dynamic_layer_id_key";
 
   @BindView(R.id.action_toolbar)
   Toolbar mToolbar;
+  @Inject
+  Iterable<ActionProvider> mActionProviders;
+
   private BaseDrawActionFragment mFragment;
 
-  public static void startSendQuadAction(Context context) {
-    startActionActivity(context, SEND_QUAD_ACTION);
-  }
-
-  public static void startMeasureAction(Context context) {
-    startActionActivity(context, MEASURE_DISTANCE_ACTION);
-  }
-
-  public static void startSendGeometryAction(Context context) {
-    startActionActivity(context, SEND_GEOMETRY_ACTION);
-  }
-
-  public static void startDynamicLayerEditAction(Context context, DynamicLayer dynamicLayer) {
-    Bundle bundle = new Bundle();
-    bundle.putString(DYNAMIC_LAYER_ID_KEY, dynamicLayer.getId());
-    startActionActivity(context, EDIT_DYNAMIC_LAYER, bundle);
-  }
-
-  public static void startFreeDrawAction(Context context) {
-    startActionActivity(context, FREE_DRAW_ACTION);
-  }
-
-  public static void startTimeplayAction(Context context) {
-    startActionActivity(context, TIMEPLAY_ACTION);
-  }
-
-  private static void startActionActivity(Context context, String action) {
+  public static void startActionActivity(Context context, String action) {
     startActionActivity(context, action, new Bundle());
   }
 
-  private static void startActionActivity(Context context, String action, Bundle bundle) {
+  public static void startActionActivity(Context context, String action, Bundle bundle) {
     Intent intent = new Intent(context, DrawActionActivity.class);
     intent.putExtra(ACTION_TAG, action);
     intent.putExtras(bundle);
@@ -89,9 +54,12 @@ public class DrawActionActivity extends BaseActivity<GGApplication> {
   @Override
   protected void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
+    getApplicationComponent().inject(this);
+
     String action = getIntent().getStringExtra(ACTION_TAG);
     if (isValidIntentAction(action)) {
-      mFragment = setupActionFragment(action);
+      mFragment = getActionFragment(action);
+      setupActionFragment(mFragment);
       setupActionBar(mFragment);
     } else {
       sLogger.e("Unknown action requested (" + action + "). Closing action-activity");
@@ -105,16 +73,18 @@ public class DrawActionActivity extends BaseActivity<GGApplication> {
   }
 
   private boolean isValidIntentAction(String action) {
-    return SEND_QUAD_ACTION.equalsIgnoreCase(action)
-        || MEASURE_DISTANCE_ACTION.equalsIgnoreCase(action)
-        || SEND_GEOMETRY_ACTION.equalsIgnoreCase(action)
-        || EDIT_DYNAMIC_LAYER.equalsIgnoreCase(action)
-        || FREE_DRAW_ACTION.equalsIgnoreCase(action)
-        || TIMEPLAY_ACTION.equalsIgnoreCase(action);
+    Iterable<String> availableActions =
+        Iterables.transform(mActionProviders, ActionProvider::getActionTag);
+    return Iterables.contains(availableActions, action);
   }
 
-  private BaseDrawActionFragment setupActionFragment(String action) {
-    BaseDrawActionFragment fragment = getActionFragment(action);
+  private BaseDrawActionFragment getActionFragment(String action) {
+    ActionProvider actionProvider =
+        Iterables.find(mActionProviders, ap -> ap.getActionTag().equalsIgnoreCase(action));
+    return actionProvider.createActionFragment(getIntent().getExtras());
+  }
+
+  private BaseDrawActionFragment setupActionFragment(BaseDrawActionFragment fragment) {
     getSupportFragmentManager().beginTransaction()
         .add(R.id.draw_action_fragment_container, fragment)
         .commit();
@@ -122,32 +92,10 @@ public class DrawActionActivity extends BaseActivity<GGApplication> {
     return fragment;
   }
 
-  private BaseDrawActionFragment getActionFragment(String action) {
-    if (SEND_QUAD_ACTION.equalsIgnoreCase(action)) {
-      return new SendQuadrilateralActionFragment();
-    } else if (MEASURE_DISTANCE_ACTION.equalsIgnoreCase(action)) {
-      return new MeasureActionFragment();
-    } else if (SEND_GEOMETRY_ACTION.equalsIgnoreCase(action)) {
-      return new SendGeometryActionFragment();
-    } else if (EDIT_DYNAMIC_LAYER.equalsIgnoreCase(action)) {
-      return EditDynamicLayerActionFragment.createFragment(getDynamicLayerId());
-    } else if (FREE_DRAW_ACTION.equalsIgnoreCase(action)) {
-      return new FreeDrawActionFragment();
-    } else if (TIMEPLAY_ACTION.equalsIgnoreCase(action)) {
-      return new TimeplayActionFragment();
-    } else {
-      throw new RuntimeException("Unsupported action - " + action);
-    }
-  }
-
   private void setupActionBar(BaseDrawActionFragment fragment) {
     setSupportActionBar(mToolbar);
     getSupportActionBar().setDisplayHomeAsUpEnabled(true);
     getSupportActionBar().setDisplayShowHomeEnabled(true);
     setTitle(fragment.getToolbarTitle());
-  }
-
-  public String getDynamicLayerId() {
-    return getIntent().getExtras().getString(DYNAMIC_LAYER_ID_KEY, null);
   }
 }

--- a/app/src/main/java/com/teamagam/gimelgimel/app/map/actions/freedraw/FreeDrawActionProvider.java
+++ b/app/src/main/java/com/teamagam/gimelgimel/app/map/actions/freedraw/FreeDrawActionProvider.java
@@ -1,0 +1,26 @@
+package com.teamagam.gimelgimel.app.map.actions.freedraw;
+
+import android.content.Context;
+import android.os.Bundle;
+import com.teamagam.gimelgimel.app.map.actions.ActionProvider;
+import com.teamagam.gimelgimel.app.map.actions.BaseDrawActionFragment;
+import com.teamagam.gimelgimel.app.map.actions.DrawActionActivity;
+
+public class FreeDrawActionProvider implements ActionProvider {
+
+  private static final String FREE_DRAW_ACTION = "free_draw";
+
+  public static void startFreeDrawAction(Context context) {
+    DrawActionActivity.startActionActivity(context, FREE_DRAW_ACTION);
+  }
+
+  @Override
+  public String getActionTag() {
+    return FREE_DRAW_ACTION;
+  }
+
+  @Override
+  public BaseDrawActionFragment createActionFragment(Bundle bundle) {
+    return new FreeDrawActionFragment();
+  }
+}

--- a/app/src/main/java/com/teamagam/gimelgimel/app/map/actions/freedraw/FreeDrawViewModel.java
+++ b/app/src/main/java/com/teamagam/gimelgimel/app/map/actions/freedraw/FreeDrawViewModel.java
@@ -9,11 +9,7 @@ import com.teamagam.gimelgimel.BR;
 import com.teamagam.gimelgimel.R;
 import com.teamagam.gimelgimel.app.map.GGMapView;
 import com.teamagam.gimelgimel.app.map.actions.BaseGeometryStyleViewModel;
-import com.teamagam.gimelgimel.domain.dynamicLayers.DisplayDynamicLayersInteractorFactory;
-import com.teamagam.gimelgimel.domain.layers.DisplayVectorLayersInteractorFactory;
-import com.teamagam.gimelgimel.domain.map.DisplayMapEntitiesInteractorFactory;
 import com.teamagam.gimelgimel.domain.map.entities.mapEntities.GeoEntity;
-import com.teamagam.gimelgimel.domain.rasters.DisplayIntermediateRastersInteractorFactory;
 import io.reactivex.Observable;
 import io.reactivex.functions.Consumer;
 import java.util.Collection;
@@ -31,16 +27,11 @@ public class FreeDrawViewModel extends BaseGeometryStyleViewModel {
   private String mEraserInactiveColor;
 
   protected FreeDrawViewModel(@Provided Context context,
-      @Provided DisplayMapEntitiesInteractorFactory displayMapEntitiesInteractorFactory,
-      @Provided DisplayVectorLayersInteractorFactory displayVectorLayersInteractorFactory,
-      @Provided DisplayDynamicLayersInteractorFactory displayDynamicLayersInteractorFactory,
       @Provided
-          DisplayIntermediateRastersInteractorFactory displayIntermediateRastersInteractorFactory,
+          com.teamagam.gimelgimel.app.map.MapEntitiesDisplayerFactory mapEntitiesDisplayerFactory,
       Consumer<Integer> pickColor,
       GGMapView ggMapView) {
-    super(displayMapEntitiesInteractorFactory, displayVectorLayersInteractorFactory,
-        displayDynamicLayersInteractorFactory, displayIntermediateRastersInteractorFactory, context,
-        ggMapView, pickColor, null);
+    super(mapEntitiesDisplayerFactory, context, ggMapView, pickColor, null);
     mPickColor = pickColor;
     mColor = getColorString(context, R.color.colorAccent);
     mEraserActiveColor = getColorString(context, R.color.md_red_500);

--- a/app/src/main/java/com/teamagam/gimelgimel/app/map/actions/measure/MeasureActionProvider.java
+++ b/app/src/main/java/com/teamagam/gimelgimel/app/map/actions/measure/MeasureActionProvider.java
@@ -1,0 +1,26 @@
+package com.teamagam.gimelgimel.app.map.actions.measure;
+
+import android.content.Context;
+import android.os.Bundle;
+import com.teamagam.gimelgimel.app.map.actions.ActionProvider;
+import com.teamagam.gimelgimel.app.map.actions.BaseDrawActionFragment;
+import com.teamagam.gimelgimel.app.map.actions.DrawActionActivity;
+
+public class MeasureActionProvider implements ActionProvider {
+
+  private static final String MEASURE_DISTANCE_ACTION = "measure";
+
+  public static void startMeasureAction(Context context) {
+    DrawActionActivity.startActionActivity(context, MEASURE_DISTANCE_ACTION);
+  }
+
+  @Override
+  public String getActionTag() {
+    return MEASURE_DISTANCE_ACTION;
+  }
+
+  @Override
+  public BaseDrawActionFragment createActionFragment(Bundle bundle) {
+    return new MeasureActionFragment();
+  }
+}

--- a/app/src/main/java/com/teamagam/gimelgimel/app/map/actions/measure/MeasureActionViewModel.java
+++ b/app/src/main/java/com/teamagam/gimelgimel/app/map/actions/measure/MeasureActionViewModel.java
@@ -1,6 +1,7 @@
 package com.teamagam.gimelgimel.app.map.actions.measure;
 
 import android.content.Context;
+import android.support.v4.content.ContextCompat;
 import com.google.auto.factory.AutoFactory;
 import com.google.auto.factory.Provided;
 import com.teamagam.gimelgimel.R;
@@ -8,15 +9,11 @@ import com.teamagam.gimelgimel.app.map.BaseMapViewModel;
 import com.teamagam.gimelgimel.app.map.GGMapView;
 import com.teamagam.gimelgimel.app.map.actions.MapDrawer;
 import com.teamagam.gimelgimel.app.map.actions.MapEntityFactory;
-import com.teamagam.gimelgimel.domain.dynamicLayers.DisplayDynamicLayersInteractorFactory;
-import com.teamagam.gimelgimel.domain.layers.DisplayVectorLayersInteractorFactory;
-import com.teamagam.gimelgimel.domain.map.DisplayMapEntitiesInteractorFactory;
 import com.teamagam.gimelgimel.domain.map.SpatialEngine;
 import com.teamagam.gimelgimel.domain.map.entities.geometries.PointGeometry;
 import com.teamagam.gimelgimel.domain.map.entities.geometries.Polyline;
 import com.teamagam.gimelgimel.domain.map.entities.symbols.PointSymbol;
 import com.teamagam.gimelgimel.domain.map.entities.symbols.PolylineSymbol;
-import com.teamagam.gimelgimel.domain.rasters.DisplayIntermediateRastersInteractorFactory;
 import java.text.DecimalFormat;
 import java.util.Arrays;
 import java.util.LinkedList;
@@ -35,16 +32,11 @@ public class MeasureActionViewModel extends BaseMapViewModel {
   private double mDistanceMeters;
 
   protected MeasureActionViewModel(@Provided Context context,
-      @Provided DisplayMapEntitiesInteractorFactory displayMapEntitiesInteractorFactory,
-      @Provided DisplayVectorLayersInteractorFactory displayVectorLayersInteractorFactory,
-      @Provided DisplayDynamicLayersInteractorFactory displayDynamicLayersInteractorFactory,
       @Provided
-          DisplayIntermediateRastersInteractorFactory displayIntermediateRastersInteractorFactory,
+          com.teamagam.gimelgimel.app.map.MapEntitiesDisplayerFactory mapEntitiesDisplayerFactory,
       @Provided SpatialEngine spatialEngine,
       GGMapView ggMapView) {
-    super(displayMapEntitiesInteractorFactory, displayVectorLayersInteractorFactory,
-        displayDynamicLayersInteractorFactory, displayIntermediateRastersInteractorFactory,
-        ggMapView);
+    super(mapEntitiesDisplayerFactory, ggMapView);
     mSpatialEngine = spatialEngine;
     mGGMapView = ggMapView;
     mMapDrawer = new MapDrawer(mGGMapView);
@@ -52,7 +44,7 @@ public class MeasureActionViewModel extends BaseMapViewModel {
     mMeasurePoints = new LinkedList<>();
     mDecimalFormatter = new DecimalFormat("#.##");
     mDistanceMeters = 0.0;
-    mColor = colorToString(context.getColor(R.color.colorAccent));
+    mColor = colorToString(ContextCompat.getColor(context, R.color.colorAccent));
   }
 
   public void onPlusClicked() {

--- a/app/src/main/java/com/teamagam/gimelgimel/app/map/actions/phase/PhaseActionFragment.java
+++ b/app/src/main/java/com/teamagam/gimelgimel/app/map/actions/phase/PhaseActionFragment.java
@@ -1,0 +1,34 @@
+package com.teamagam.gimelgimel.app.map.actions.phase;
+
+import android.support.v4.view.PagerTabStrip;
+import android.support.v4.view.ViewPager;
+import butterknife.BindView;
+import com.teamagam.gimelgimel.R;
+import com.teamagam.gimelgimel.app.common.base.ViewModels.BaseViewModel;
+import com.teamagam.gimelgimel.app.map.actions.BaseDrawActionFragment;
+
+public class PhaseActionFragment extends BaseDrawActionFragment {
+
+  @BindView(R.id.phase_view_pager)
+  ViewPager mViewPager;
+
+  @BindView(R.id.phase_pager)
+  PagerTabStrip mPagerTabStrip;
+
+  private PhaseViewModel mPhaseViewModel;
+
+  @Override
+  protected BaseViewModel getSpecificViewModel() {
+    return mPhaseViewModel;
+  }
+
+  @Override
+  protected String getToolbarTitle() {
+    return getString(R.string.phase_action_title);
+  }
+
+  @Override
+  protected int getFragmentLayout() {
+    return R.layout.fragment_phase;
+  }
+}

--- a/app/src/main/java/com/teamagam/gimelgimel/app/map/actions/phase/PhaseActionFragment.java
+++ b/app/src/main/java/com/teamagam/gimelgimel/app/map/actions/phase/PhaseActionFragment.java
@@ -65,7 +65,7 @@ public class PhaseActionFragment extends BaseDrawActionFragment
 
     mViewModel =
         mPhaseViewModelFactory.create(new BottomFragmentPanelPhasesDisplayer(phasesPagerAdapter),
-            mGGMapView, getBundledLayerId());
+            getBundledLayerId());
 
     return view;
   }
@@ -73,6 +73,7 @@ public class PhaseActionFragment extends BaseDrawActionFragment
   @Override
   public void onDynamicEntityListingClicked(DynamicEntity dynamicEntity) {
     //
+    mViewModel.onPhaseEntityClicked(dynamicEntity);
   }
 
   @Override

--- a/app/src/main/java/com/teamagam/gimelgimel/app/map/actions/phase/PhaseActionFragment.java
+++ b/app/src/main/java/com/teamagam/gimelgimel/app/map/actions/phase/PhaseActionFragment.java
@@ -70,7 +70,6 @@ public class PhaseActionFragment extends BaseDrawActionFragment
 
   @Override
   public void onDynamicEntityListingClicked(DynamicEntity dynamicEntity) {
-    //
     mViewModel.onPhaseEntityClicked(dynamicEntity);
   }
 

--- a/app/src/main/java/com/teamagam/gimelgimel/app/map/actions/phase/PhaseActionFragment.java
+++ b/app/src/main/java/com/teamagam/gimelgimel/app/map/actions/phase/PhaseActionFragment.java
@@ -1,5 +1,9 @@
 package com.teamagam.gimelgimel.app.map.actions.phase;
 
+import android.os.Bundle;
+import android.support.v4.app.Fragment;
+import android.support.v4.app.FragmentManager;
+import android.support.v4.app.FragmentStatePagerAdapter;
 import android.support.v4.view.PagerTabStrip;
 import android.support.v4.view.ViewPager;
 import butterknife.BindView;
@@ -9,17 +13,35 @@ import com.teamagam.gimelgimel.app.map.actions.BaseDrawActionFragment;
 
 public class PhaseActionFragment extends BaseDrawActionFragment {
 
+  private static final String PHASE_LAYER_ID_KEY = "phase_layer_id";
+
   @BindView(R.id.phase_view_pager)
   ViewPager mViewPager;
-
   @BindView(R.id.phase_pager)
   PagerTabStrip mPagerTabStrip;
 
-  private PhaseViewModel mPhaseViewModel;
+  private PhaseViewModel mViewModel;
+
+  public static PhaseActionFragment createFragment(String phaseLayerId) {
+    Bundle bundle = new Bundle();
+    bundle.putString(PHASE_LAYER_ID_KEY, phaseLayerId);
+    PhaseActionFragment fragment = new PhaseActionFragment();
+    fragment.setArguments(bundle);
+    return fragment;
+  }
+
+  @Override
+  public void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    mViewPager.setAdapter(new PhasesPagerAdapter(getChildFragmentManager()));
+
+    String phaseLayerId = getArguments().getString(PHASE_LAYER_ID_KEY);
+    mViewModel = null;
+  }
 
   @Override
   protected BaseViewModel getSpecificViewModel() {
-    return mPhaseViewModel;
+    return mViewModel;
   }
 
   @Override
@@ -30,5 +52,27 @@ public class PhaseActionFragment extends BaseDrawActionFragment {
   @Override
   protected int getFragmentLayout() {
     return R.layout.fragment_phase;
+  }
+
+  private class PhasesPagerAdapter extends FragmentStatePagerAdapter {
+
+    public PhasesPagerAdapter(FragmentManager fm) {
+      super(fm);
+    }
+
+    @Override
+    public Fragment getItem(int position) {
+      return null;
+    }
+
+    @Override
+    public CharSequence getPageTitle(int position) {
+      return super.getPageTitle(position);
+    }
+
+    @Override
+    public int getCount() {
+      return 0;
+    }
   }
 }

--- a/app/src/main/java/com/teamagam/gimelgimel/app/map/actions/phase/PhaseActionFragment.java
+++ b/app/src/main/java/com/teamagam/gimelgimel/app/map/actions/phase/PhaseActionFragment.java
@@ -39,6 +39,8 @@ public class PhaseActionFragment extends BaseDrawActionFragment
   PhaseViewModelFactory mPhaseViewModelFactory;
 
   private PhaseViewModel mViewModel;
+  private DelegatePhaseSelectionListener mPhaseSelectionListener;
+  private PhasesPagerAdapter mPhasesPagerAdapter;
 
   public static PhaseActionFragment newInstance(String phaseLayerId) {
     Bundle bundle = new Bundle();
@@ -60,12 +62,8 @@ public class PhaseActionFragment extends BaseDrawActionFragment
       Bundle savedInstanceState) {
     View view = super.onCreateView(inflater, container, savedInstanceState);
 
-    PhasesPagerAdapter phasesPagerAdapter = new PhasesPagerAdapter(getChildFragmentManager());
-    mViewPager.setAdapter(phasesPagerAdapter);
-
-    mViewModel =
-        mPhaseViewModelFactory.create(new BottomFragmentPanelPhasesDisplayer(phasesPagerAdapter),
-            getBundledLayerId());
+    initializePager();
+    initializeViewModel();
 
     return view;
   }
@@ -74,6 +72,12 @@ public class PhaseActionFragment extends BaseDrawActionFragment
   public void onDynamicEntityListingClicked(DynamicEntity dynamicEntity) {
     //
     mViewModel.onPhaseEntityClicked(dynamicEntity);
+  }
+
+  @Override
+  public void onDestroyView() {
+    super.onDestroyView();
+    mViewPager.removeOnPageChangeListener(mPhaseSelectionListener);
   }
 
   @Override
@@ -89,6 +93,18 @@ public class PhaseActionFragment extends BaseDrawActionFragment
   @Override
   protected int getFragmentLayout() {
     return R.layout.fragment_phase;
+  }
+
+  private void initializePager() {
+    mPhasesPagerAdapter = new PhasesPagerAdapter(getChildFragmentManager());
+    mViewPager.setAdapter(mPhasesPagerAdapter);
+    mPhaseSelectionListener = new DelegatePhaseSelectionListener();
+    mViewPager.addOnPageChangeListener(mPhaseSelectionListener);
+  }
+
+  private void initializeViewModel() {
+    mViewModel = mPhaseViewModelFactory.create(mGGMapView,
+        new BottomFragmentPanelPhasesDisplayer(mPhasesPagerAdapter), getBundledLayerId());
   }
 
   private String getBundledLayerId() {
@@ -152,6 +168,14 @@ public class PhaseActionFragment extends BaseDrawActionFragment
       } else {
         mPhases.add(position, phase);
       }
+    }
+  }
+
+  private class DelegatePhaseSelectionListener extends ViewPager.SimpleOnPageChangeListener {
+    @Override
+    public void onPageSelected(int position) {
+      super.onPageSelected(position);
+      mViewModel.onPhaseSelected(position);
     }
   }
 }

--- a/app/src/main/java/com/teamagam/gimelgimel/app/map/actions/phase/PhaseActionProvider.java
+++ b/app/src/main/java/com/teamagam/gimelgimel/app/map/actions/phase/PhaseActionProvider.java
@@ -24,6 +24,6 @@ public class PhaseActionProvider implements ActionProvider {
 
   @Override
   public BaseDrawActionFragment createActionFragment(Bundle bundle) {
-    return PhaseActionFragment.createFragment(bundle.getString(PHASE_LAYER_ID_KEY));
+    return PhaseActionFragment.newInstance(bundle.getString(PHASE_LAYER_ID_KEY));
   }
 }

--- a/app/src/main/java/com/teamagam/gimelgimel/app/map/actions/phase/PhaseActionProvider.java
+++ b/app/src/main/java/com/teamagam/gimelgimel/app/map/actions/phase/PhaseActionProvider.java
@@ -1,0 +1,26 @@
+package com.teamagam.gimelgimel.app.map.actions.phase;
+
+import android.content.Context;
+import android.os.Bundle;
+import com.teamagam.gimelgimel.app.map.actions.ActionProvider;
+import com.teamagam.gimelgimel.app.map.actions.BaseDrawActionFragment;
+import com.teamagam.gimelgimel.app.map.actions.DrawActionActivity;
+
+public class PhaseActionProvider implements ActionProvider {
+
+  private static final String PHASE_ACTION = "phase";
+
+  public static void startPhaseAction(Context context) {
+    DrawActionActivity.startActionActivity(context, PHASE_ACTION);
+  }
+
+  @Override
+  public String getActionTag() {
+    return PHASE_ACTION;
+  }
+
+  @Override
+  public BaseDrawActionFragment createActionFragment(Bundle bundle) {
+    return new PhaseActionFragment();
+  }
+}

--- a/app/src/main/java/com/teamagam/gimelgimel/app/map/actions/phase/PhaseActionProvider.java
+++ b/app/src/main/java/com/teamagam/gimelgimel/app/map/actions/phase/PhaseActionProvider.java
@@ -9,9 +9,12 @@ import com.teamagam.gimelgimel.app.map.actions.DrawActionActivity;
 public class PhaseActionProvider implements ActionProvider {
 
   private static final String PHASE_ACTION = "phase";
+  private static final String PHASE_LAYER_ID_KEY = "phase_layer_id";
 
-  public static void startPhaseAction(Context context) {
-    DrawActionActivity.startActionActivity(context, PHASE_ACTION);
+  public static void startPhaseAction(Context context, String phaseLayerId) {
+    Bundle bundle = new Bundle();
+    bundle.putString(PHASE_LAYER_ID_KEY, phaseLayerId);
+    DrawActionActivity.startActionActivity(context, PHASE_ACTION, bundle);
   }
 
   @Override
@@ -21,6 +24,6 @@ public class PhaseActionProvider implements ActionProvider {
 
   @Override
   public BaseDrawActionFragment createActionFragment(Bundle bundle) {
-    return new PhaseActionFragment();
+    return PhaseActionFragment.createFragment(bundle.getString(PHASE_LAYER_ID_KEY));
   }
 }

--- a/app/src/main/java/com/teamagam/gimelgimel/app/map/actions/phase/PhaseFragment.java
+++ b/app/src/main/java/com/teamagam/gimelgimel/app/map/actions/phase/PhaseFragment.java
@@ -1,0 +1,17 @@
+package com.teamagam.gimelgimel.app.map.actions.phase;
+
+import com.teamagam.gimelgimel.app.common.base.ViewModels.BaseViewModel;
+import com.teamagam.gimelgimel.app.common.base.view.fragments.BaseViewModelFragment;
+
+public class PhaseFragment extends BaseViewModelFragment {
+
+  @Override
+  protected BaseViewModel getSpecificViewModel() {
+    return null;
+  }
+
+  @Override
+  protected int getFragmentLayout() {
+    return 0;
+  }
+}

--- a/app/src/main/java/com/teamagam/gimelgimel/app/map/actions/phase/PhaseViewModel.java
+++ b/app/src/main/java/com/teamagam/gimelgimel/app/map/actions/phase/PhaseViewModel.java
@@ -1,15 +1,25 @@
 package com.teamagam.gimelgimel.app.map.actions.phase;
 
 import com.google.auto.factory.AutoFactory;
-import com.teamagam.gimelgimel.app.common.base.ViewModels.BaseViewModel;
+import com.google.auto.factory.Provided;
+import com.teamagam.gimelgimel.app.common.logging.AppLogger;
+import com.teamagam.gimelgimel.app.common.logging.AppLoggerFactory;
+import com.teamagam.gimelgimel.app.map.BaseMapViewModel;
+import com.teamagam.gimelgimel.app.map.GGMapView;
+import com.teamagam.gimelgimel.domain.dynamicLayers.DisplayDynamicLayersInteractorFactory;
 import com.teamagam.gimelgimel.domain.dynamicLayers.entity.DynamicLayer;
+import com.teamagam.gimelgimel.domain.layers.DisplayVectorLayersInteractorFactory;
+import com.teamagam.gimelgimel.domain.map.DisplayMapEntitiesInteractorFactory;
 import com.teamagam.gimelgimel.domain.phase.DisplayPhaseLayerInteractor;
 import com.teamagam.gimelgimel.domain.phase.DisplayPhaseLayerInteractorFactory;
 import com.teamagam.gimelgimel.domain.phase.PhaseLayer;
-import javax.inject.Inject;
+import com.teamagam.gimelgimel.domain.rasters.DisplayIntermediateRastersInteractorFactory;
+import java.util.List;
 
 @AutoFactory
-public class PhaseViewModel extends BaseViewModel {
+public class PhaseViewModel extends BaseMapViewModel {
+
+  private static final AppLogger sLogger = AppLoggerFactory.create();
 
   private final DisplayPhaseLayerInteractorFactory mDisplayPhaseLayerInteractorFactory;
   private final PhasesDisplayer mPhasesDisplayer;
@@ -17,10 +27,19 @@ public class PhaseViewModel extends BaseViewModel {
 
   private DisplayPhaseLayerInteractor mDisplayInteractor;
 
-  @Inject
-  public PhaseViewModel(DisplayPhaseLayerInteractorFactory displayPhaseLayerInteractorFactory,
+  public PhaseViewModel(
+      @Provided DisplayPhaseLayerInteractorFactory displayPhaseLayerInteractorFactory,
+      @Provided DisplayMapEntitiesInteractorFactory displayMapEntitiesInteractorFactory,
+      @Provided DisplayVectorLayersInteractorFactory displayVectorLayersInteractorFactory,
+      @Provided DisplayDynamicLayersInteractorFactory displayDynamicLayersInteractorFactory,
+      @Provided
+          DisplayIntermediateRastersInteractorFactory displayIntermediateRastersInteractorFactory,
       PhasesDisplayer phasesDisplayer,
+      GGMapView ggMapView,
       String phaseLayerId) {
+    super(displayMapEntitiesInteractorFactory, displayVectorLayersInteractorFactory,
+        displayDynamicLayersInteractorFactory, displayIntermediateRastersInteractorFactory,
+        ggMapView);
     mPhasesDisplayer = phasesDisplayer;
     mPhaseLayerId = phaseLayerId;
     mDisplayPhaseLayerInteractorFactory = displayPhaseLayerInteractorFactory;
@@ -47,13 +66,16 @@ public class PhaseViewModel extends BaseViewModel {
 
   private void displayPhaseLayer(PhaseLayer layer) {
     //display name, description, timestamp(?)
+    sLogger.i("Displaying phase layer " + layer);
     displayPhases(layer);
   }
 
   private void displayPhases(PhaseLayer layer) {
-    int position = 0;
-    for (DynamicLayer phase : layer.getPhases()) {
-      mPhasesDisplayer.addPhase(phase, position++);
+    List<DynamicLayer> phases = layer.getPhases();
+
+    sLogger.i("Displaying " + phases.size() + " phases");
+    for (int i = 0; i < phases.size(); i++) {
+      mPhasesDisplayer.addPhase(phases.get(i), i);
     }
   }
 

--- a/app/src/main/java/com/teamagam/gimelgimel/app/map/actions/phase/PhaseViewModel.java
+++ b/app/src/main/java/com/teamagam/gimelgimel/app/map/actions/phase/PhaseViewModel.java
@@ -2,22 +2,18 @@ package com.teamagam.gimelgimel.app.map.actions.phase;
 
 import com.google.auto.factory.AutoFactory;
 import com.google.auto.factory.Provided;
+import com.teamagam.gimelgimel.app.common.base.ViewModels.BaseViewModel;
 import com.teamagam.gimelgimel.app.common.logging.AppLogger;
 import com.teamagam.gimelgimel.app.common.logging.AppLoggerFactory;
-import com.teamagam.gimelgimel.app.map.BaseMapViewModel;
-import com.teamagam.gimelgimel.app.map.GGMapView;
-import com.teamagam.gimelgimel.domain.dynamicLayers.DisplayDynamicLayersInteractorFactory;
+import com.teamagam.gimelgimel.domain.dynamicLayers.entity.DynamicEntity;
 import com.teamagam.gimelgimel.domain.dynamicLayers.entity.DynamicLayer;
-import com.teamagam.gimelgimel.domain.layers.DisplayVectorLayersInteractorFactory;
-import com.teamagam.gimelgimel.domain.map.DisplayMapEntitiesInteractorFactory;
 import com.teamagam.gimelgimel.domain.phase.DisplayPhaseLayerInteractor;
 import com.teamagam.gimelgimel.domain.phase.DisplayPhaseLayerInteractorFactory;
 import com.teamagam.gimelgimel.domain.phase.PhaseLayer;
-import com.teamagam.gimelgimel.domain.rasters.DisplayIntermediateRastersInteractorFactory;
 import java.util.List;
 
 @AutoFactory
-public class PhaseViewModel extends BaseMapViewModel {
+public class PhaseViewModel extends BaseViewModel {
 
   private static final AppLogger sLogger = AppLoggerFactory.create();
 
@@ -29,17 +25,8 @@ public class PhaseViewModel extends BaseMapViewModel {
 
   public PhaseViewModel(
       @Provided DisplayPhaseLayerInteractorFactory displayPhaseLayerInteractorFactory,
-      @Provided DisplayMapEntitiesInteractorFactory displayMapEntitiesInteractorFactory,
-      @Provided DisplayVectorLayersInteractorFactory displayVectorLayersInteractorFactory,
-      @Provided DisplayDynamicLayersInteractorFactory displayDynamicLayersInteractorFactory,
-      @Provided
-          DisplayIntermediateRastersInteractorFactory displayIntermediateRastersInteractorFactory,
       PhasesDisplayer phasesDisplayer,
-      GGMapView ggMapView,
       String phaseLayerId) {
-    super(displayMapEntitiesInteractorFactory, displayVectorLayersInteractorFactory,
-        displayDynamicLayersInteractorFactory, displayIntermediateRastersInteractorFactory,
-        ggMapView);
     mPhasesDisplayer = phasesDisplayer;
     mPhaseLayerId = phaseLayerId;
     mDisplayPhaseLayerInteractorFactory = displayPhaseLayerInteractorFactory;
@@ -62,6 +49,10 @@ public class PhaseViewModel extends BaseMapViewModel {
   public void onPhaseSelected(int phasePosition) {
     //draw phase on map
     mPhasesDisplayer.displayPhase(phasePosition);
+  }
+
+  public void onPhaseEntityClicked(DynamicEntity dynamicEntity) {
+
   }
 
   private void displayPhaseLayer(PhaseLayer layer) {

--- a/app/src/main/java/com/teamagam/gimelgimel/app/map/actions/phase/PhaseViewModel.java
+++ b/app/src/main/java/com/teamagam/gimelgimel/app/map/actions/phase/PhaseViewModel.java
@@ -5,6 +5,9 @@ import com.google.auto.factory.Provided;
 import com.teamagam.gimelgimel.app.common.base.ViewModels.BaseViewModel;
 import com.teamagam.gimelgimel.app.common.logging.AppLogger;
 import com.teamagam.gimelgimel.app.common.logging.AppLoggerFactory;
+import com.teamagam.gimelgimel.app.map.DynamicLayersMapDisplayer;
+import com.teamagam.gimelgimel.app.map.GGMapView;
+import com.teamagam.gimelgimel.domain.dynamicLayers.DynamicLayerPresentation;
 import com.teamagam.gimelgimel.domain.dynamicLayers.entity.DynamicEntity;
 import com.teamagam.gimelgimel.domain.dynamicLayers.entity.DynamicLayer;
 import com.teamagam.gimelgimel.domain.phase.DisplayPhaseLayerInteractor;
@@ -20,16 +23,22 @@ public class PhaseViewModel extends BaseViewModel {
   private final DisplayPhaseLayerInteractorFactory mDisplayPhaseLayerInteractorFactory;
   private final PhasesDisplayer mPhasesDisplayer;
   private final String mPhaseLayerId;
-
+  private final GGMapView mGGMapView;
+  private final DynamicLayersMapDisplayer mMapDisplayer;
   private DisplayPhaseLayerInteractor mDisplayInteractor;
+  private PhaseLayer mPhaseLayer;
+  private DynamicLayer mCurrentlyDisplayedPhase;
 
   public PhaseViewModel(
       @Provided DisplayPhaseLayerInteractorFactory displayPhaseLayerInteractorFactory,
+      GGMapView GGMapView,
       PhasesDisplayer phasesDisplayer,
       String phaseLayerId) {
     mPhasesDisplayer = phasesDisplayer;
     mPhaseLayerId = phaseLayerId;
     mDisplayPhaseLayerInteractorFactory = displayPhaseLayerInteractorFactory;
+    mGGMapView = GGMapView;
+    mMapDisplayer = new DynamicLayersMapDisplayer(mGGMapView);
   }
 
   @Override
@@ -38,6 +47,7 @@ public class PhaseViewModel extends BaseViewModel {
     mDisplayInteractor =
         mDisplayPhaseLayerInteractorFactory.create(this::displayPhaseLayer, mPhaseLayerId);
     execute(mDisplayInteractor);
+    displayFirstPhaseOnMap();
   }
 
   @Override
@@ -47,8 +57,29 @@ public class PhaseViewModel extends BaseViewModel {
   }
 
   public void onPhaseSelected(int phasePosition) {
-    //draw phase on map
-    mPhasesDisplayer.displayPhase(phasePosition);
+    DynamicLayer phase = mPhaseLayer.getPhase(phasePosition);
+    displayPhaseOnMap(phase);
+  }
+
+  private void displayPhaseOnMap(DynamicLayer phase) {
+    clearOldPhase();
+    showPhase(phase);
+  }
+
+  private void clearOldPhase() {
+    if (mCurrentlyDisplayedPhase != null) {
+      hidePhase();
+    }
+  }
+
+  private void hidePhase() {
+    mMapDisplayer.display(new DynamicLayerPresentation(mCurrentlyDisplayedPhase, false));
+    mCurrentlyDisplayedPhase = null;
+  }
+
+  private void showPhase(DynamicLayer phase) {
+    mMapDisplayer.display(new DynamicLayerPresentation(phase, true));
+    mCurrentlyDisplayedPhase = phase;
   }
 
   public void onPhaseEntityClicked(DynamicEntity dynamicEntity) {
@@ -58,7 +89,16 @@ public class PhaseViewModel extends BaseViewModel {
   private void displayPhaseLayer(PhaseLayer layer) {
     //display name, description, timestamp(?)
     sLogger.i("Displaying phase layer " + layer);
+    mPhaseLayer = layer;
     displayPhases(layer);
+  }
+
+  private void displayFirstPhaseOnMap() {
+    mGGMapView.setOnReadyListener(() -> {
+      if (mPhaseLayer != null) {
+        displayPhaseOnMap(mPhaseLayer.getPhase(0));
+      }
+    });
   }
 
   private void displayPhases(PhaseLayer layer) {

--- a/app/src/main/java/com/teamagam/gimelgimel/app/map/actions/phase/PhaseViewModel.java
+++ b/app/src/main/java/com/teamagam/gimelgimel/app/map/actions/phase/PhaseViewModel.java
@@ -1,0 +1,7 @@
+package com.teamagam.gimelgimel.app.map.actions.phase;
+
+import com.teamagam.gimelgimel.app.common.base.ViewModels.BaseViewModel;
+
+public class PhaseViewModel extends BaseViewModel {
+
+}

--- a/app/src/main/java/com/teamagam/gimelgimel/app/map/actions/phase/PhaseViewModel.java
+++ b/app/src/main/java/com/teamagam/gimelgimel/app/map/actions/phase/PhaseViewModel.java
@@ -7,9 +7,11 @@ import com.teamagam.gimelgimel.app.common.logging.AppLogger;
 import com.teamagam.gimelgimel.app.common.logging.AppLoggerFactory;
 import com.teamagam.gimelgimel.app.map.DynamicLayersMapDisplayer;
 import com.teamagam.gimelgimel.app.map.GGMapView;
+import com.teamagam.gimelgimel.domain.dynamicLayers.DynamicLayerGoToGeometryCalculator;
 import com.teamagam.gimelgimel.domain.dynamicLayers.DynamicLayerPresentation;
 import com.teamagam.gimelgimel.domain.dynamicLayers.entity.DynamicEntity;
 import com.teamagam.gimelgimel.domain.dynamicLayers.entity.DynamicLayer;
+import com.teamagam.gimelgimel.domain.map.entities.geometries.Geometry;
 import com.teamagam.gimelgimel.domain.phase.DisplayPhaseLayerInteractor;
 import com.teamagam.gimelgimel.domain.phase.DisplayPhaseLayerInteractorFactory;
 import com.teamagam.gimelgimel.domain.phase.PhaseLayer;
@@ -56,9 +58,14 @@ public class PhaseViewModel extends BaseViewModel {
     unsubscribe(mDisplayInteractor);
   }
 
+  public void onPhaseEntityClicked(DynamicEntity dynamicEntity) {
+    mGGMapView.lookAt(dynamicEntity.getGeoEntity().getGeometry());
+  }
+
   public void onPhaseSelected(int phasePosition) {
     DynamicLayer phase = mPhaseLayer.getPhase(phasePosition);
     displayPhaseOnMap(phase);
+    lookAtPhase(phase);
   }
 
   private void displayPhaseOnMap(DynamicLayer phase) {
@@ -82,8 +89,9 @@ public class PhaseViewModel extends BaseViewModel {
     mCurrentlyDisplayedPhase = phase;
   }
 
-  public void onPhaseEntityClicked(DynamicEntity dynamicEntity) {
-
+  private void lookAtPhase(DynamicLayer phase) {
+    Geometry goToTarget = new DynamicLayerGoToGeometryCalculator().getGoToTarget(phase);
+    mGGMapView.lookAt(goToTarget);
   }
 
   private void displayPhaseLayer(PhaseLayer layer) {
@@ -96,7 +104,9 @@ public class PhaseViewModel extends BaseViewModel {
   private void displayFirstPhaseOnMap() {
     mGGMapView.setOnReadyListener(() -> {
       if (mPhaseLayer != null) {
-        displayPhaseOnMap(mPhaseLayer.getPhase(0));
+        DynamicLayer firstPhase = mPhaseLayer.getPhase(0);
+        displayPhaseOnMap(firstPhase);
+        lookAtPhase(firstPhase);
       }
     });
   }

--- a/app/src/main/java/com/teamagam/gimelgimel/app/map/actions/phase/PhaseViewModel.java
+++ b/app/src/main/java/com/teamagam/gimelgimel/app/map/actions/phase/PhaseViewModel.java
@@ -1,7 +1,65 @@
 package com.teamagam.gimelgimel.app.map.actions.phase;
 
+import com.google.auto.factory.AutoFactory;
 import com.teamagam.gimelgimel.app.common.base.ViewModels.BaseViewModel;
+import com.teamagam.gimelgimel.domain.dynamicLayers.entity.DynamicLayer;
+import com.teamagam.gimelgimel.domain.phase.DisplayPhaseLayerInteractor;
+import com.teamagam.gimelgimel.domain.phase.DisplayPhaseLayerInteractorFactory;
+import com.teamagam.gimelgimel.domain.phase.PhaseLayer;
+import javax.inject.Inject;
 
+@AutoFactory
 public class PhaseViewModel extends BaseViewModel {
 
+  private final DisplayPhaseLayerInteractorFactory mDisplayPhaseLayerInteractorFactory;
+  private final PhasesDisplayer mPhasesDisplayer;
+  private final String mPhaseLayerId;
+
+  private DisplayPhaseLayerInteractor mDisplayInteractor;
+
+  @Inject
+  public PhaseViewModel(DisplayPhaseLayerInteractorFactory displayPhaseLayerInteractorFactory,
+      PhasesDisplayer phasesDisplayer,
+      String phaseLayerId) {
+    mPhasesDisplayer = phasesDisplayer;
+    mPhaseLayerId = phaseLayerId;
+    mDisplayPhaseLayerInteractorFactory = displayPhaseLayerInteractorFactory;
+  }
+
+  @Override
+  public void start() {
+    super.start();
+    mDisplayInteractor =
+        mDisplayPhaseLayerInteractorFactory.create(this::displayPhaseLayer, mPhaseLayerId);
+    execute(mDisplayInteractor);
+  }
+
+  @Override
+  public void stop() {
+    super.stop();
+    unsubscribe(mDisplayInteractor);
+  }
+
+  public void onPhaseSelected(int phasePosition) {
+    //draw phase on map
+    mPhasesDisplayer.displayPhase(phasePosition);
+  }
+
+  private void displayPhaseLayer(PhaseLayer layer) {
+    //display name, description, timestamp(?)
+    displayPhases(layer);
+  }
+
+  private void displayPhases(PhaseLayer layer) {
+    int position = 0;
+    for (DynamicLayer phase : layer.getPhases()) {
+      mPhasesDisplayer.addPhase(phase, position++);
+    }
+  }
+
+  interface PhasesDisplayer {
+    void addPhase(DynamicLayer phase, int position);
+
+    void displayPhase(int position);
+  }
 }

--- a/app/src/main/java/com/teamagam/gimelgimel/app/map/actions/send/dynamicLayers/EditDynamicLayerActionFragment.java
+++ b/app/src/main/java/com/teamagam/gimelgimel/app/map/actions/send/dynamicLayers/EditDynamicLayerActionFragment.java
@@ -152,7 +152,7 @@ public class EditDynamicLayerActionFragment
 
   private void initDetailsPanel() {
     DynamicLayerDetailsFragment dynamicLayerDetailsFragment =
-        DynamicLayerDetailsFragment.newInstance(getDynamicLayerId(), null);
+        DynamicLayerDetailsFragment.newInstance(getDynamicLayerId());
     getChildFragmentManager().beginTransaction()
         .add(R.id.dynamic_layer_edit_details_placeholder, dynamicLayerDetailsFragment)
         .commit();

--- a/app/src/main/java/com/teamagam/gimelgimel/app/map/actions/send/dynamicLayers/EditDynamicLayerActionProvider.java
+++ b/app/src/main/java/com/teamagam/gimelgimel/app/map/actions/send/dynamicLayers/EditDynamicLayerActionProvider.java
@@ -1,0 +1,34 @@
+package com.teamagam.gimelgimel.app.map.actions.send.dynamicLayers;
+
+import android.content.Context;
+import android.os.Bundle;
+import com.teamagam.gimelgimel.app.map.actions.ActionProvider;
+import com.teamagam.gimelgimel.app.map.actions.BaseDrawActionFragment;
+import com.teamagam.gimelgimel.app.map.actions.DrawActionActivity;
+import com.teamagam.gimelgimel.domain.dynamicLayers.entity.DynamicLayer;
+
+public class EditDynamicLayerActionProvider implements ActionProvider {
+
+  private static final String EDIT_DYNAMIC_LAYER = "edit_dynamic_layer";
+  private static final String DYNAMIC_LAYER_ID_KEY = "dynamic_layer_id_key";
+
+  public static void startDynamicLayerEditAction(Context context, DynamicLayer dynamicLayer) {
+    Bundle bundle = new Bundle();
+    bundle.putString(DYNAMIC_LAYER_ID_KEY, dynamicLayer.getId());
+    DrawActionActivity.startActionActivity(context, EDIT_DYNAMIC_LAYER, bundle);
+  }
+
+  @Override
+  public String getActionTag() {
+    return EDIT_DYNAMIC_LAYER;
+  }
+
+  @Override
+  public BaseDrawActionFragment createActionFragment(Bundle bundle) {
+    return EditDynamicLayerActionFragment.createFragment(getDynamicLayerId(bundle));
+  }
+
+  private String getDynamicLayerId(Bundle bundle) {
+    return bundle.getString(DYNAMIC_LAYER_ID_KEY, null);
+  }
+}

--- a/app/src/main/java/com/teamagam/gimelgimel/app/map/actions/send/dynamicLayers/EditDynamicLayerViewModel.java
+++ b/app/src/main/java/com/teamagam/gimelgimel/app/map/actions/send/dynamicLayers/EditDynamicLayerViewModel.java
@@ -21,14 +21,11 @@ import com.teamagam.gimelgimel.domain.dynamicLayers.remote.SendRemoteRemoveDynam
 import com.teamagam.gimelgimel.domain.icons.DisplayIconsInteractor;
 import com.teamagam.gimelgimel.domain.icons.DisplayIconsInteractorFactory;
 import com.teamagam.gimelgimel.domain.icons.entities.Icon;
-import com.teamagam.gimelgimel.domain.layers.DisplayVectorLayersInteractorFactory;
-import com.teamagam.gimelgimel.domain.map.DisplayMapEntitiesInteractorFactory;
 import com.teamagam.gimelgimel.domain.map.entities.mapEntities.GeoEntity;
 import com.teamagam.gimelgimel.domain.map.entities.symbols.PointSymbol;
 import com.teamagam.gimelgimel.domain.map.entities.symbols.PolygonSymbol;
 import com.teamagam.gimelgimel.domain.map.entities.symbols.PolylineSymbol;
 import com.teamagam.gimelgimel.domain.map.entities.symbols.Symbol;
-import com.teamagam.gimelgimel.domain.rasters.DisplayIntermediateRastersInteractorFactory;
 import io.reactivex.functions.Consumer;
 import java.util.Collection;
 
@@ -59,11 +56,9 @@ public class EditDynamicLayerViewModel extends BaseGeometryStyleViewModel {
   private SymbolFactory mSymbolFactory;
 
   protected EditDynamicLayerViewModel(@Provided Context context,
-      @Provided DisplayMapEntitiesInteractorFactory displayMapEntitiesInteractorFactory,
-      @Provided DisplayVectorLayersInteractorFactory displayVectorLayersInteractorFactory,
-      @Provided DisplayDynamicLayersInteractorFactory displayDynamicLayersInteractorFactory,
       @Provided
-          DisplayIntermediateRastersInteractorFactory displayIntermediateRastersInteractorFactory,
+          com.teamagam.gimelgimel.app.map.MapEntitiesDisplayerFactory mapEntitiesDisplayerFactory,
+      @Provided DisplayDynamicLayersInteractorFactory displayDynamicLayersInteractorFactory,
       @Provided DisplayIconsInteractorFactory displayIconsInteractorFactory,
       @Provided
           SendRemoteAddDynamicEntityRequestInteractorFactory addDynamicEntityRequestInteractorFactory,
@@ -78,9 +73,7 @@ public class EditDynamicLayerViewModel extends BaseGeometryStyleViewModel {
       Consumer<String> pickBorderStyle,
       Consumer<Icon> iconDisplayer,
       String dynamicLayerId) {
-    super(displayMapEntitiesInteractorFactory, displayVectorLayersInteractorFactory,
-        displayDynamicLayersInteractorFactory, displayIntermediateRastersInteractorFactory, context,
-        ggMapView, pickColor, pickBorderStyle);
+    super(mapEntitiesDisplayerFactory, context, ggMapView, pickColor, pickBorderStyle);
     mDisplayIconsInteractorFactory = displayIconsInteractorFactory;
     mAddDynamicEntityRequestInteractorFactory = addDynamicEntityRequestInteractorFactory;
     mNavigator = navigator;

--- a/app/src/main/java/com/teamagam/gimelgimel/app/map/actions/send/geometry/SendGeometryActionProvider.java
+++ b/app/src/main/java/com/teamagam/gimelgimel/app/map/actions/send/geometry/SendGeometryActionProvider.java
@@ -1,0 +1,26 @@
+package com.teamagam.gimelgimel.app.map.actions.send.geometry;
+
+import android.content.Context;
+import android.os.Bundle;
+import com.teamagam.gimelgimel.app.map.actions.ActionProvider;
+import com.teamagam.gimelgimel.app.map.actions.BaseDrawActionFragment;
+import com.teamagam.gimelgimel.app.map.actions.DrawActionActivity;
+
+public class SendGeometryActionProvider implements ActionProvider {
+
+  private static final String SEND_GEOMETRY_ACTION = "send_geometry";
+
+  public static void startSendGeometryAction(Context context) {
+    DrawActionActivity.startActionActivity(context, SEND_GEOMETRY_ACTION);
+  }
+
+  @Override
+  public String getActionTag() {
+    return SEND_GEOMETRY_ACTION;
+  }
+
+  @Override
+  public BaseDrawActionFragment createActionFragment(Bundle bundle) {
+    return new SendGeometryActionFragment();
+  }
+}

--- a/app/src/main/java/com/teamagam/gimelgimel/app/map/actions/send/geometry/SendGeometryViewModel.java
+++ b/app/src/main/java/com/teamagam/gimelgimel/app/map/actions/send/geometry/SendGeometryViewModel.java
@@ -11,9 +11,6 @@ import com.teamagam.gimelgimel.app.map.GGMapView;
 import com.teamagam.gimelgimel.app.map.actions.BaseGeometryStyleViewModel;
 import com.teamagam.gimelgimel.app.map.actions.MapDrawer;
 import com.teamagam.gimelgimel.app.map.actions.MapEntityFactory;
-import com.teamagam.gimelgimel.domain.dynamicLayers.DisplayDynamicLayersInteractorFactory;
-import com.teamagam.gimelgimel.domain.layers.DisplayVectorLayersInteractorFactory;
-import com.teamagam.gimelgimel.domain.map.DisplayMapEntitiesInteractorFactory;
 import com.teamagam.gimelgimel.domain.map.entities.geometries.Geometry;
 import com.teamagam.gimelgimel.domain.map.entities.geometries.PointGeometry;
 import com.teamagam.gimelgimel.domain.map.entities.geometries.Polygon;
@@ -23,7 +20,6 @@ import com.teamagam.gimelgimel.domain.map.entities.symbols.PolygonSymbol;
 import com.teamagam.gimelgimel.domain.map.entities.symbols.PolylineSymbol;
 import com.teamagam.gimelgimel.domain.map.entities.symbols.Symbol;
 import com.teamagam.gimelgimel.domain.messages.QueueGeoMessageForSendingInteractorFactory;
-import com.teamagam.gimelgimel.domain.rasters.DisplayIntermediateRastersInteractorFactory;
 import io.reactivex.functions.Consumer;
 import java.util.ArrayList;
 import java.util.List;
@@ -44,20 +40,15 @@ public class SendGeometryViewModel extends BaseGeometryStyleViewModel {
   private String mDisabledColor;
 
   protected SendGeometryViewModel(@Provided Context context,
-      @Provided DisplayMapEntitiesInteractorFactory displayMapEntitiesInteractorFactory,
-      @Provided DisplayVectorLayersInteractorFactory displayVectorLayersInteractorFactory,
-      @Provided DisplayDynamicLayersInteractorFactory displayDynamicLayersInteractorFactory,
       @Provided
-          DisplayIntermediateRastersInteractorFactory displayIntermediateRastersInteractorFactory,
+          com.teamagam.gimelgimel.app.map.MapEntitiesDisplayerFactory mapEntitiesDisplayerFactory,
       @Provided QueueGeoMessageForSendingInteractorFactory sendGeoMessageInteractorFactory,
       GGMapView ggMapView,
       InvalidInputNotifier invalidInputNotifier,
       Consumer<Integer> pickColor,
       Consumer<String> pickBorderStyle,
       ViewDismisser viewDismisser) {
-    super(displayMapEntitiesInteractorFactory, displayVectorLayersInteractorFactory,
-        displayDynamicLayersInteractorFactory, displayIntermediateRastersInteractorFactory, context,
-        ggMapView, pickColor, pickBorderStyle);
+    super(mapEntitiesDisplayerFactory, context, ggMapView, pickColor, pickBorderStyle);
     mInvalidInputNotifier = invalidInputNotifier;
     mPickColor = pickColor;
     mPickBorderStyle = pickBorderStyle;

--- a/app/src/main/java/com/teamagam/gimelgimel/app/map/actions/send/quadrilateral/SendQuadrilateralActionProvider.java
+++ b/app/src/main/java/com/teamagam/gimelgimel/app/map/actions/send/quadrilateral/SendQuadrilateralActionProvider.java
@@ -1,0 +1,26 @@
+package com.teamagam.gimelgimel.app.map.actions.send.quadrilateral;
+
+import android.content.Context;
+import android.os.Bundle;
+import com.teamagam.gimelgimel.app.map.actions.ActionProvider;
+import com.teamagam.gimelgimel.app.map.actions.BaseDrawActionFragment;
+import com.teamagam.gimelgimel.app.map.actions.DrawActionActivity;
+
+public class SendQuadrilateralActionProvider implements ActionProvider {
+
+  private static final String SEND_QUAD_ACTION = "send_quad";
+
+  public static void startSendQuadAction(Context context) {
+    DrawActionActivity.startActionActivity(context, SEND_QUAD_ACTION);
+  }
+
+  @Override
+  public String getActionTag() {
+    return SEND_QUAD_ACTION;
+  }
+
+  @Override
+  public BaseDrawActionFragment createActionFragment(Bundle bundle) {
+    return new SendQuadrilateralActionFragment();
+  }
+}

--- a/app/src/main/java/com/teamagam/gimelgimel/app/map/actions/send/quadrilateral/SendQuadrilateralActionViewModel.java
+++ b/app/src/main/java/com/teamagam/gimelgimel/app/map/actions/send/quadrilateral/SendQuadrilateralActionViewModel.java
@@ -9,15 +9,11 @@ import com.teamagam.gimelgimel.app.map.BaseMapViewModel;
 import com.teamagam.gimelgimel.app.map.GGMapView;
 import com.teamagam.gimelgimel.app.map.actions.MapDrawer;
 import com.teamagam.gimelgimel.app.map.actions.MapEntityFactory;
-import com.teamagam.gimelgimel.domain.dynamicLayers.DisplayDynamicLayersInteractorFactory;
-import com.teamagam.gimelgimel.domain.layers.DisplayVectorLayersInteractorFactory;
-import com.teamagam.gimelgimel.domain.map.DisplayMapEntitiesInteractorFactory;
 import com.teamagam.gimelgimel.domain.map.entities.geometries.PointGeometry;
 import com.teamagam.gimelgimel.domain.map.entities.geometries.Polygon;
 import com.teamagam.gimelgimel.domain.map.entities.symbols.PolygonSymbol;
 import com.teamagam.gimelgimel.domain.map.entities.symbols.Symbol;
 import com.teamagam.gimelgimel.domain.messages.QueueGeoMessageForSendingInteractorFactory;
-import com.teamagam.gimelgimel.domain.rasters.DisplayIntermediateRastersInteractorFactory;
 import com.teamagam.gimelgimel.domain.utils.PreferencesUtils;
 import com.teamagam.gimelgimel.domain.utils.TextUtils;
 import java.util.ArrayList;
@@ -39,20 +35,14 @@ public class SendQuadrilateralActionViewModel
   private SharedPreferences mDefaultSharedPreferences;
   private boolean mUseUtmMode;
 
-  SendQuadrilateralActionViewModel(
-      @Provided DisplayMapEntitiesInteractorFactory mapEntitiesInteractorFactory,
-      @Provided DisplayVectorLayersInteractorFactory displayVectorLayersInteractorFactory,
-      @Provided DisplayDynamicLayersInteractorFactory displayDynamicLayersInteractorFactory,
-      @Provided
-          DisplayIntermediateRastersInteractorFactory displayIntermediateRastersInteractorFactory,
+  SendQuadrilateralActionViewModel(@Provided
+      com.teamagam.gimelgimel.app.map.MapEntitiesDisplayerFactory mapEntitiesDisplayerFactory,
       @Provided QueueGeoMessageForSendingInteractorFactory sendGeoMessageInteractorFactory,
       @Provided PreferencesUtils preferencesUtils,
       GGMapView ggMapView,
       SendQuadrilateralActionFragment view,
       LatLongPicker[] pickers) {
-    super(mapEntitiesInteractorFactory, displayVectorLayersInteractorFactory,
-        displayDynamicLayersInteractorFactory, displayIntermediateRastersInteractorFactory,
-        ggMapView);
+    super(mapEntitiesDisplayerFactory, ggMapView);
     mSendGeoMessageInteractorFactory = sendGeoMessageInteractorFactory;
     mUseUtmMode = preferencesUtils.shouldUseUtm();
     mGGMapView = ggMapView;

--- a/app/src/main/java/com/teamagam/gimelgimel/app/map/actions/timeplay/TimeplayActionProvider.java
+++ b/app/src/main/java/com/teamagam/gimelgimel/app/map/actions/timeplay/TimeplayActionProvider.java
@@ -1,0 +1,26 @@
+package com.teamagam.gimelgimel.app.map.actions.timeplay;
+
+import android.content.Context;
+import android.os.Bundle;
+import com.teamagam.gimelgimel.app.map.actions.ActionProvider;
+import com.teamagam.gimelgimel.app.map.actions.BaseDrawActionFragment;
+import com.teamagam.gimelgimel.app.map.actions.DrawActionActivity;
+
+public class TimeplayActionProvider implements ActionProvider {
+
+  private static final String TIMEPLAY_ACTION = "timeplay";
+
+  public static void startTimeplayAction(Context context) {
+    DrawActionActivity.startActionActivity(context, TIMEPLAY_ACTION);
+  }
+
+  @Override
+  public String getActionTag() {
+    return TIMEPLAY_ACTION;
+  }
+
+  @Override
+  public BaseDrawActionFragment createActionFragment(Bundle bundle) {
+    return new TimeplayActionFragment();
+  }
+}

--- a/app/src/main/java/com/teamagam/gimelgimel/app/map/main/ViewerViewModel.java
+++ b/app/src/main/java/com/teamagam/gimelgimel/app/map/main/ViewerViewModel.java
@@ -9,17 +9,13 @@ import com.teamagam.gimelgimel.app.map.BaseMapViewModel;
 import com.teamagam.gimelgimel.app.map.GGMapView;
 import com.teamagam.gimelgimel.app.map.MapEntityClickedListener;
 import com.teamagam.gimelgimel.app.map.OnMapGestureListener;
-import com.teamagam.gimelgimel.domain.dynamicLayers.DisplayDynamicLayersInteractorFactory;
-import com.teamagam.gimelgimel.domain.layers.DisplayVectorLayersInteractorFactory;
 import com.teamagam.gimelgimel.domain.map.ActOnFirstLocationInteractorFactory;
-import com.teamagam.gimelgimel.domain.map.DisplayMapEntitiesInteractorFactory;
 import com.teamagam.gimelgimel.domain.map.OnEntityClickedInteractorFactory;
 import com.teamagam.gimelgimel.domain.map.SelectKmlEntityInteractorFactory;
 import com.teamagam.gimelgimel.domain.map.ViewerCameraController;
 import com.teamagam.gimelgimel.domain.map.entities.geometries.Geometry;
 import com.teamagam.gimelgimel.domain.map.entities.geometries.PointGeometry;
 import com.teamagam.gimelgimel.domain.map.entities.mapEntities.KmlEntityInfo;
-import com.teamagam.gimelgimel.domain.rasters.DisplayIntermediateRastersInteractorFactory;
 
 @AutoFactory
 public class ViewerViewModel extends BaseMapViewModel<ViewerFragment>
@@ -35,20 +31,14 @@ public class ViewerViewModel extends BaseMapViewModel<ViewerFragment>
 
   private boolean mLocateMeEnabled;
 
-  public ViewerViewModel(
-      @Provided DisplayMapEntitiesInteractorFactory displayMapEntitiesInteractorFactory,
-      @Provided DisplayVectorLayersInteractorFactory displayVectorLayersInteractorFactory,
-      @Provided DisplayDynamicLayersInteractorFactory displayDynamicLayersInteractorFactory,
-      @Provided
-          DisplayIntermediateRastersInteractorFactory displayIntermediateRastersInteractorFactory,
+  public ViewerViewModel(@Provided
+      com.teamagam.gimelgimel.app.map.MapEntitiesDisplayerFactory mapEntitiesDisplayerFactory,
       @Provided SelectKmlEntityInteractorFactory selectKmlEntityInfoInteractorFactory,
       @Provided OnEntityClickedInteractorFactory onEntityClickedInteractorFactory,
       @Provided ActOnFirstLocationInteractorFactory actOnFirstLocationInteractorFactory,
       @Provided Navigator navigator,
       GGMapView ggMapView) {
-    super(displayMapEntitiesInteractorFactory, displayVectorLayersInteractorFactory,
-        displayDynamicLayersInteractorFactory, displayIntermediateRastersInteractorFactory,
-        ggMapView);
+    super(mapEntitiesDisplayerFactory, ggMapView);
     mSelectKmlEntityInfoInteractorFactory = selectKmlEntityInfoInteractorFactory;
     mOnEntityClickedInteractorFactory = onEntityClickedInteractorFactory;
     mActOnFirstLocationInteractorFactory = actOnFirstLocationInteractorFactory;

--- a/app/src/main/res/layout/fragment_phase.xml
+++ b/app/src/main/res/layout/fragment_phase.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    >
+  <com.teamagam.gimelgimel.app.map.esri.EsriGGMapView
+      android:layout_width="match_parent"
+      android:layout_height="0dp"
+      android:layout_weight="7"
+      />
+  <android.support.v4.view.ViewPager
+      android:id="@+id/phase_view_pager"
+      android:layout_width="match_parent"
+      android:layout_height="0dp"
+      android:layout_weight="3"
+      >
+    <android.support.v4.view.PagerTabStrip
+        android:id="@+id/phase_pager"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        />
+  </android.support.v4.view.ViewPager>
+
+</LinearLayout>

--- a/app/src/main/res/layout/fragment_phase.xml
+++ b/app/src/main/res/layout/fragment_phase.xml
@@ -5,6 +5,7 @@
     android:orientation="vertical"
     >
   <com.teamagam.gimelgimel.app.map.esri.EsriGGMapView
+      android:id="@+id/phase_map"
       android:layout_width="match_parent"
       android:layout_height="0dp"
       android:layout_weight="7"

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -112,4 +112,5 @@
   <string name="dynamic_layer_details_entity_title">יישות #%1$d</string>
   <string name="dynamic_layer_details_layer_title">שכבה - %1$s</string>
   <string name="drawer_layers_category_name_phase_layers">שכבות שלבים</string>
+  <string name="phase_action_title">שכבת שלבים</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -198,6 +198,10 @@
   <string name="search">Search</string>
   <string name="search_result">%1$d of %2$d</string>
 
+
+  <!--Phase action-->
+  <string name="phase_action_title">Phase layer</string>
+
   <string-array name="border_styles">
     <item>none</item>
     <item>solid</item>

--- a/app/src/test/java/com/teamagam/gimelgimel/app/map/DynamicLayersInteractorDisplayerTest.java
+++ b/app/src/test/java/com/teamagam/gimelgimel/app/map/DynamicLayersInteractorDisplayerTest.java
@@ -25,7 +25,7 @@ public class DynamicLayersInteractorDisplayerTest {
   private static final String DESCRIPTION = "";
 
   private GGMapView mMapSpy;
-  private BaseMapViewModel.DynamicLayersInteractorDisplayer mDisplayer;
+  private MapEntitiesDisplayer.DynamicLayersInteractorDisplayer mDisplayer;
 
   private GeoEntity mEntity1;
   private DynamicLayer mDynamicLayer;
@@ -48,8 +48,7 @@ public class DynamicLayersInteractorDisplayerTest {
   @Before
   public void setUp() throws Exception {
     mMapSpy = spy(GGMapView.class);
-    BaseMapViewModel model = new BaseMapViewModel(null, null, null, null, mMapSpy);
-    mDisplayer = model.new DynamicLayersInteractorDisplayer(); // inner class
+    mDisplayer = new MapEntitiesDisplayer.DynamicLayersInteractorDisplayer(mMapSpy);
 
     mEntity1 = mock(GeoEntity.class);
     when(mEntity1.getId()).thenReturn("entity_id_1");

--- a/app/src/test/java/com/teamagam/gimelgimel/app/map/DynamicLayersInteractorDisplayerTest.java
+++ b/app/src/test/java/com/teamagam/gimelgimel/app/map/DynamicLayersInteractorDisplayerTest.java
@@ -25,7 +25,7 @@ public class DynamicLayersInteractorDisplayerTest {
   private static final String DESCRIPTION = "";
 
   private GGMapView mMapSpy;
-  private MapEntitiesDisplayer.DynamicLayersInteractorDisplayer mDisplayer;
+  private DynamicLayersMapDisplayer mDisplayer;
 
   private GeoEntity mEntity1;
   private DynamicLayer mDynamicLayer;
@@ -48,7 +48,7 @@ public class DynamicLayersInteractorDisplayerTest {
   @Before
   public void setUp() throws Exception {
     mMapSpy = spy(GGMapView.class);
-    mDisplayer = new MapEntitiesDisplayer.DynamicLayersInteractorDisplayer(mMapSpy);
+    mDisplayer = new DynamicLayersMapDisplayer(mMapSpy);
 
     mEntity1 = mock(GeoEntity.class);
     when(mEntity1.getId()).thenReturn("entity_id_1");

--- a/domain/src/main/java/com/teamagam/gimelgimel/domain/dynamicLayers/DisplayDynamicLayerDetailsInteractor.java
+++ b/domain/src/main/java/com/teamagam/gimelgimel/domain/dynamicLayers/DisplayDynamicLayerDetailsInteractor.java
@@ -8,29 +8,41 @@ import com.teamagam.gimelgimel.domain.base.interactors.BaseSingleDisplayInteract
 import com.teamagam.gimelgimel.domain.base.interactors.DisplaySubscriptionRequest;
 import com.teamagam.gimelgimel.domain.dynamicLayers.entity.DynamicLayer;
 import com.teamagam.gimelgimel.domain.dynamicLayers.repository.DynamicLayersRepository;
+import com.teamagam.gimelgimel.domain.phase.PhaseLayer;
+import com.teamagam.gimelgimel.domain.phase.PhaseLayerRepository;
+import io.reactivex.Observable;
 
 @AutoFactory
 public class DisplayDynamicLayerDetailsInteractor extends BaseSingleDisplayInteractor {
 
   private final DynamicLayersRepository mDynamicLayersRepository;
+  private final PhaseLayerRepository mPhaseLayerRepository;
   private final String mDynamicLayerId;
   private final Displayer mDisplayer;
 
   public DisplayDynamicLayerDetailsInteractor(@Provided ThreadExecutor threadExecutor,
       @Provided PostExecutionThread postExecutionThread,
       @Provided DynamicLayersRepository dynamicLayersRepository,
+      @Provided PhaseLayerRepository phaseLayerRepository,
       Displayer displayer,
       String dynamicLayerId) {
     super(threadExecutor, postExecutionThread);
     mDynamicLayersRepository = dynamicLayersRepository;
+    mPhaseLayerRepository = phaseLayerRepository;
     mDisplayer = displayer;
     mDynamicLayerId = dynamicLayerId;
   }
 
   @Override
   protected SubscriptionRequest buildSubscriptionRequest(DisplaySubscriptionRequest.DisplaySubscriptionRequestFactory factory) {
-    return factory.create(mDynamicLayersRepository.getObservable(),
-        dlsObs -> dlsObs.filter(dl -> dl.getId().equals(mDynamicLayerId)), mDisplayer::display);
+    return factory.create(Observable.just(mDynamicLayersRepository),
+        repoObsrv -> repoObsrv.flatMap(DynamicLayersRepository::getObservable)
+            .mergeWith(getFlattenedPhasesObservable())
+            .filter(dl -> dl.getId().equals(mDynamicLayerId)), mDisplayer::display);
+  }
+
+  private Observable<DynamicLayer> getFlattenedPhasesObservable() {
+    return mPhaseLayerRepository.getObservable().flatMapIterable(PhaseLayer::getPhases);
   }
 
   public interface Displayer {

--- a/domain/src/main/java/com/teamagam/gimelgimel/domain/dynamicLayers/DynamicLayerGoToGeometryCalculator.java
+++ b/domain/src/main/java/com/teamagam/gimelgimel/domain/dynamicLayers/DynamicLayerGoToGeometryCalculator.java
@@ -1,0 +1,101 @@
+package com.teamagam.gimelgimel.domain.dynamicLayers;
+
+import com.google.common.collect.Lists;
+import com.teamagam.gimelgimel.domain.dynamicLayers.entity.DynamicLayer;
+import com.teamagam.gimelgimel.domain.map.entities.geometries.Geometry;
+import com.teamagam.gimelgimel.domain.map.entities.geometries.PointGeometry;
+import com.teamagam.gimelgimel.domain.map.entities.geometries.Polygon;
+import com.teamagam.gimelgimel.domain.map.entities.geometries.Polyline;
+import com.teamagam.gimelgimel.domain.map.entities.interfaces.GeometryVisitor;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class DynamicLayerGoToGeometryCalculator {
+
+  private final DynamicLayerEnvelopeExtractor mDynamicLayerEnvelopeExtractor;
+
+  public DynamicLayerGoToGeometryCalculator() {
+    mDynamicLayerEnvelopeExtractor = new DynamicLayerEnvelopeExtractor();
+  }
+
+  public Geometry getGoToTarget(DynamicLayer dl) {
+    if (hasOnePoint(dl)) {
+      return getFirstGeometry(dl);
+    } else {
+      return mDynamicLayerEnvelopeExtractor.extract(dl);
+    }
+  }
+
+  private boolean hasOnePoint(DynamicLayer dl) {
+    return dl.getEntities().size() == 1 && getFirstGeometry(dl) instanceof PointGeometry;
+  }
+
+  private Geometry getFirstGeometry(DynamicLayer dl) {
+    return dl.getEntities().get(0).getGeoEntity().getGeometry();
+  }
+
+  private class DynamicLayerEnvelopeExtractor {
+
+    private ExtractPointsVisitor mPointsExtractorVisitor = new ExtractPointsVisitor();
+
+    public Geometry extract(DynamicLayer dl) {
+      List<PointGeometry> allPoints =
+          getAllPoints(Lists.transform(dl.getEntities(), de -> de.getGeoEntity().getGeometry()));
+      return buildEnvelope(allPoints);
+    }
+
+    private List<PointGeometry> getAllPoints(List<Geometry> geometries) {
+      List<PointGeometry> res = new ArrayList<>();
+      for (Geometry g : geometries) {
+        g.accept(mPointsExtractorVisitor);
+        res.addAll(mPointsExtractorVisitor.getPoints());
+      }
+      return res;
+    }
+
+    private Geometry buildEnvelope(List<PointGeometry> allPoints) {
+      List<Double> lats = Lists.transform(allPoints, PointGeometry::getLatitude);
+      List<Double> longs = Lists.transform(allPoints, PointGeometry::getLongitude);
+
+      double minX = Collections.min(lats);
+      double maxX = Collections.max(lats);
+
+      double minY = Collections.min(longs);
+      double maxY = Collections.max(longs);
+
+      return createEnvelope(minX, maxX, minY, maxY);
+    }
+
+    private Geometry createEnvelope(double minX, double maxX, double minY, double maxY) {
+      PointGeometry bottomLeft = new PointGeometry(minX, minY);
+      PointGeometry topLeft = new PointGeometry(minX, maxY);
+      PointGeometry topRight = new PointGeometry(maxX, maxY);
+      PointGeometry bottomRight = new PointGeometry(maxX, minY);
+      return new Polygon(Lists.newArrayList(bottomLeft, topLeft, topRight, bottomRight));
+    }
+
+    private class ExtractPointsVisitor implements GeometryVisitor {
+      List<PointGeometry> mPoints = new ArrayList<>();
+
+      @Override
+      public void visit(PointGeometry point) {
+        mPoints.add(point);
+      }
+
+      @Override
+      public void visit(Polygon polygon) {
+        mPoints = polygon.getPoints();
+      }
+
+      @Override
+      public void visit(Polyline polyline) {
+        mPoints = polyline.getPoints();
+      }
+
+      public List<PointGeometry> getPoints() {
+        return mPoints;
+      }
+    }
+  }
+}

--- a/domain/src/main/java/com/teamagam/gimelgimel/domain/dynamicLayers/OnDynamicLayerListingClickInteractor.java
+++ b/domain/src/main/java/com/teamagam/gimelgimel/domain/dynamicLayers/OnDynamicLayerListingClickInteractor.java
@@ -2,7 +2,6 @@ package com.teamagam.gimelgimel.domain.dynamicLayers;
 
 import com.google.auto.factory.AutoFactory;
 import com.google.auto.factory.Provided;
-import com.google.common.collect.Lists;
 import com.teamagam.gimelgimel.domain.base.executor.ThreadExecutor;
 import com.teamagam.gimelgimel.domain.base.interactors.BaseSingleDataInteractor;
 import com.teamagam.gimelgimel.domain.base.interactors.DataSubscriptionRequest;
@@ -10,15 +9,7 @@ import com.teamagam.gimelgimel.domain.dynamicLayers.entity.DynamicLayer;
 import com.teamagam.gimelgimel.domain.dynamicLayers.repository.DynamicLayerVisibilityRepository;
 import com.teamagam.gimelgimel.domain.dynamicLayers.repository.DynamicLayersRepository;
 import com.teamagam.gimelgimel.domain.map.GoToLocationMapInteractorFactory;
-import com.teamagam.gimelgimel.domain.map.entities.geometries.Geometry;
-import com.teamagam.gimelgimel.domain.map.entities.geometries.PointGeometry;
-import com.teamagam.gimelgimel.domain.map.entities.geometries.Polygon;
-import com.teamagam.gimelgimel.domain.map.entities.geometries.Polyline;
-import com.teamagam.gimelgimel.domain.map.entities.interfaces.GeometryVisitor;
 import io.reactivex.Observable;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
 
 @AutoFactory
 public class OnDynamicLayerListingClickInteractor extends BaseSingleDataInteractor {
@@ -26,7 +17,7 @@ public class OnDynamicLayerListingClickInteractor extends BaseSingleDataInteract
   private final DynamicLayerVisibilityRepository mDynamicLayerVisibilityRepository;
   private final DynamicLayersRepository mDynamicLayersRepository;
   private final GoToLocationMapInteractorFactory mGoToLocationMapInteractorFactory;
-  private final DynamicLayerEnvelopeExtractor mDynamicLayerEnvelopeExtractor;
+  private final DynamicLayerGoToGeometryCalculator mDynamicLayerGoToGeometryCalculator;
   private final String mDynamicLayerId;
 
   protected OnDynamicLayerListingClickInteractor(@Provided ThreadExecutor threadExecutor,
@@ -39,7 +30,7 @@ public class OnDynamicLayerListingClickInteractor extends BaseSingleDataInteract
     mDynamicLayerVisibilityRepository = dynamicLayerVisibilityRepository;
     mDynamicLayersRepository = dynamicLayersRepository;
     mGoToLocationMapInteractorFactory = goToLocationMapInteractorFactory;
-    mDynamicLayerEnvelopeExtractor = new DynamicLayerEnvelopeExtractor();
+    mDynamicLayerGoToGeometryCalculator = new DynamicLayerGoToGeometryCalculator();
     mDynamicLayerId = dynamicLayerId;
   }
 
@@ -69,86 +60,7 @@ public class OnDynamicLayerListingClickInteractor extends BaseSingleDataInteract
   }
 
   private void goToExtent(DynamicLayer dl) {
-    mGoToLocationMapInteractorFactory.create(getGoToTarget(dl)).execute();
-  }
-
-  private Geometry getGoToTarget(DynamicLayer dl) {
-    if (hasOnePoint(dl)) {
-      return getFirstGeometry(dl);
-    } else {
-      return mDynamicLayerEnvelopeExtractor.extract(dl);
-    }
-  }
-
-  private boolean hasOnePoint(DynamicLayer dl) {
-    return dl.getEntities().size() == 1 && getFirstGeometry(dl) instanceof PointGeometry;
-  }
-
-  private Geometry getFirstGeometry(DynamicLayer dl) {
-    return dl.getEntities().get(0).getGeoEntity().getGeometry();
-  }
-
-  private class DynamicLayerEnvelopeExtractor {
-
-    private ExtractPointsVisitor mPointsExtractorVisitor = new ExtractPointsVisitor();
-
-    public Geometry extract(DynamicLayer dl) {
-      List<PointGeometry> allPoints =
-          getAllPoints(Lists.transform(dl.getEntities(), de -> de.getGeoEntity().getGeometry()));
-      return buildEnvelope(allPoints);
-    }
-
-    private List<PointGeometry> getAllPoints(List<Geometry> geometries) {
-      List<PointGeometry> res = new ArrayList<>();
-      for (Geometry g : geometries) {
-        g.accept(mPointsExtractorVisitor);
-        res.addAll(mPointsExtractorVisitor.getPoints());
-      }
-      return res;
-    }
-
-    private Geometry buildEnvelope(List<PointGeometry> allPoints) {
-      List<Double> lats = Lists.transform(allPoints, PointGeometry::getLatitude);
-      List<Double> longs = Lists.transform(allPoints, PointGeometry::getLongitude);
-
-      double minX = Collections.min(lats);
-      double maxX = Collections.max(lats);
-
-      double minY = Collections.min(longs);
-      double maxY = Collections.max(longs);
-
-      return createEnvelope(minX, maxX, minY, maxY);
-    }
-
-    private Geometry createEnvelope(double minX, double maxX, double minY, double maxY) {
-      PointGeometry bottomLeft = new PointGeometry(minX, minY);
-      PointGeometry topLeft = new PointGeometry(minX, maxY);
-      PointGeometry topRight = new PointGeometry(maxX, maxY);
-      PointGeometry bottomRight = new PointGeometry(maxX, minY);
-      return new Polygon(Lists.newArrayList(bottomLeft, topLeft, topRight, bottomRight));
-    }
-
-    private class ExtractPointsVisitor implements GeometryVisitor {
-      List<PointGeometry> mPoints = new ArrayList<>();
-
-      @Override
-      public void visit(PointGeometry point) {
-        mPoints.add(point);
-      }
-
-      @Override
-      public void visit(Polygon polygon) {
-        mPoints = polygon.getPoints();
-      }
-
-      @Override
-      public void visit(Polyline polyline) {
-        mPoints = polyline.getPoints();
-      }
-
-      public List<PointGeometry> getPoints() {
-        return mPoints;
-      }
-    }
+    mGoToLocationMapInteractorFactory.create(mDynamicLayerGoToGeometryCalculator.getGoToTarget(dl))
+        .execute();
   }
 }

--- a/domain/src/main/java/com/teamagam/gimelgimel/domain/phase/DisplayPhaseLayerInteractor.java
+++ b/domain/src/main/java/com/teamagam/gimelgimel/domain/phase/DisplayPhaseLayerInteractor.java
@@ -1,0 +1,38 @@
+package com.teamagam.gimelgimel.domain.phase;
+
+import com.google.auto.factory.AutoFactory;
+import com.google.auto.factory.Provided;
+import com.teamagam.gimelgimel.domain.base.executor.PostExecutionThread;
+import com.teamagam.gimelgimel.domain.base.executor.ThreadExecutor;
+import com.teamagam.gimelgimel.domain.base.interactors.BaseSingleDisplayInteractor;
+import com.teamagam.gimelgimel.domain.base.interactors.DisplaySubscriptionRequest;
+import io.reactivex.Observable;
+
+@AutoFactory
+public class DisplayPhaseLayerInteractor extends BaseSingleDisplayInteractor {
+
+  private final PhaseLayerRepository mPhaseLayerRepository;
+  private final Displayer mDisplayer;
+  private final String mPhaseLayerId;
+
+  public DisplayPhaseLayerInteractor(@Provided ThreadExecutor threadExecutor,
+      @Provided PostExecutionThread postExecutionThread,
+      @Provided PhaseLayerRepository phaseLayerRepository,
+      Displayer displayer,
+      String phaseLayerId) {
+    super(threadExecutor, postExecutionThread);
+    mPhaseLayerRepository = phaseLayerRepository;
+    mDisplayer = displayer;
+    mPhaseLayerId = phaseLayerId;
+  }
+
+  @Override
+  protected SubscriptionRequest buildSubscriptionRequest(DisplaySubscriptionRequest.DisplaySubscriptionRequestFactory factory) {
+    return factory.create(Observable.just(mPhaseLayerId),
+        idObsv -> idObsv.map(mPhaseLayerRepository::getById), mDisplayer::display);
+  }
+
+  public interface Displayer {
+    void display(PhaseLayer layer);
+  }
+}

--- a/domain/src/main/java/com/teamagam/gimelgimel/domain/phase/visibility/DisplayPhaseLayersInteractor.java
+++ b/domain/src/main/java/com/teamagam/gimelgimel/domain/phase/visibility/DisplayPhaseLayersInteractor.java
@@ -11,13 +11,13 @@ import com.teamagam.gimelgimel.domain.phase.PhaseLayerRepository;
 import io.reactivex.Observable;
 
 @AutoFactory
-public class DisplayPhaseLayerInteractor extends BaseSingleDisplayInteractor {
+public class DisplayPhaseLayersInteractor extends BaseSingleDisplayInteractor {
 
   private final PhaseLayerVisibilityRepository mVisibilityRepository;
   private final PhaseLayerRepository mPhaseLayerRepository;
   private final Displayer mDisplayer;
 
-  public DisplayPhaseLayerInteractor(@Provided ThreadExecutor threadExecutor,
+  public DisplayPhaseLayersInteractor(@Provided ThreadExecutor threadExecutor,
       @Provided PostExecutionThread postExecutionThread,
       @Provided PhaseLayerVisibilityRepository visibilityRepository,
       @Provided PhaseLayerRepository phaseLayerRepository,

--- a/domain/src/main/java/com/teamagam/gimelgimel/domain/phase/visibility/OnPhaseLayerListingClickInteractor.java
+++ b/domain/src/main/java/com/teamagam/gimelgimel/domain/phase/visibility/OnPhaseLayerListingClickInteractor.java
@@ -1,0 +1,42 @@
+package com.teamagam.gimelgimel.domain.phase.visibility;
+
+import com.google.auto.factory.AutoFactory;
+import com.google.auto.factory.Provided;
+import com.teamagam.gimelgimel.domain.base.executor.ThreadExecutor;
+import com.teamagam.gimelgimel.domain.base.interactors.BaseSingleDataInteractor;
+import com.teamagam.gimelgimel.domain.base.interactors.DataSubscriptionRequest;
+import com.teamagam.gimelgimel.domain.phase.PhaseLayer;
+import com.teamagam.gimelgimel.domain.phase.PhaseLayerRepository;
+import io.reactivex.Observable;
+
+@AutoFactory
+public class OnPhaseLayerListingClickInteractor extends BaseSingleDataInteractor {
+
+  private final PhaseLayerVisibilityRepository mPhaseLayerVisibilityRepository;
+  private final PhaseLayerRepository mPhaseLayerRepository;
+  private final String mPhaseLayerId;
+
+  protected OnPhaseLayerListingClickInteractor(@Provided ThreadExecutor threadExecutor,
+      @Provided PhaseLayerVisibilityRepository phaseLayerVisibilityRepository,
+      @Provided PhaseLayerRepository phaseLayerRepository,
+      String phaseLayerId) {
+    super(threadExecutor);
+    mPhaseLayerVisibilityRepository = phaseLayerVisibilityRepository;
+    mPhaseLayerRepository = phaseLayerRepository;
+    mPhaseLayerId = phaseLayerId;
+  }
+
+  @Override
+  protected SubscriptionRequest buildSubscriptionRequest(DataSubscriptionRequest.SubscriptionRequestFactory factory) {
+    return factory.create(Observable.just(mPhaseLayerId),
+        idOsb -> idOsb.map(mPhaseLayerRepository::getById)
+            .map(this::getToggledVisibilityChange)
+            .doOnNext(mPhaseLayerVisibilityRepository::addChange));
+  }
+
+  private PhaseLayerVisibilityChange getToggledVisibilityChange(PhaseLayer phaseLayer) {
+    String phaseLayerId = phaseLayer.getId();
+    boolean toggledVisibility = !mPhaseLayerVisibilityRepository.isVisible(phaseLayerId);
+    return new PhaseLayerVisibilityChange(toggledVisibility, phaseLayerId);
+  }
+}


### PR DESCRIPTION
Phase display action added to the app.
Allows the user to see each phase seperately in its own action view.
The phase-action-view is accessible through the drawer layers section.

Some refactoring was done in BaseMapViewModel to simplify new types of data to be added to the map display.

Phase layers are displayed over the map (and can be hidden through the drawer layer menu, just like any other layer).

It is also worth mentioning that ActionProvider(s) were introduced.
These classes allows adding new actions (measure, send geo, send quad..., etc) easily and without change to the base-code (other than dagger code)